### PR TITLE
Fix phpunit nearest

### DIFF
--- a/autoload/test/base.vim
+++ b/autoload/test/base.vim
@@ -97,7 +97,7 @@ function! test#base#nearest_test_in_lines(filename, from_line, to_line, patterns
   let current_line = a:from_line + 1
   let test_line    = -1
 
-  let is_reverse = '$' == a:from_line ? v:true : a:from_line > a:to_line
+  let is_reverse = '$' == a:from_line ? 1 : a:from_line > a:to_line
   let lines = is_reverse
     \ ? reverse(getbufline(a:filename, a:to_line, a:from_line))
     \ : getbufline(a:filename, a:from_line, a:to_line)

--- a/autoload/test/base.vim
+++ b/autoload/test/base.vim
@@ -69,14 +69,41 @@ endfunction
 "
 "   {
 "     'test': ['test_calculates_time'],
+"     'test_line': 54, " Line where 'test_calculates_time' was found
 "     'namespace': ['CalculatorTest'],
 "   }
 function! test#base#nearest_test(position, patterns) abort
-  let test        = []
-  let namespace   = []
-  let last_indent = -1
+  return test#base#nearest_test_in_lines(a:position['file'], a:position['line'], 1, a:patterns)
+endfunction
 
-  for line in reverse(getbufline(a:position['file'], 1, a:position['line']))
+" This function is used internally by the test#base#nearest_test function
+" So it behaves exactly like describe for test#base#nearest_test except that
+" it can search forward or backward depending on the search range.
+"
+" Instead of taking a "position" argument, this function takes 3:
+"   - "filename" is the equivalent of "position['file']"
+"   - "from_line" the line number from where to start the search, is the
+"   equivalent fo "position['line']"
+"   - "to_line" the line number where to end the search (it would be 1 in
+"   test#base#nearest_test)
+"
+" If "from_line" is greater than "to_line" or equals '$' then the search will
+" be backward.
+" Otherwise it will be forward.
+function! test#base#nearest_test_in_lines(filename, from_line, to_line, patterns) abort
+  let test         = []
+  let namespace    = []
+  let last_indent  = -1
+  let current_line = a:from_line + 1
+  let test_line    = -1
+
+  let is_reverse = '$' == a:from_line ? v:true : a:from_line > a:to_line
+  let lines = is_reverse
+    \ ? reverse(getbufline(a:filename, a:to_line, a:from_line))
+    \ : getbufline(a:filename, a:from_line, a:to_line)
+
+  for line in lines
+    let current_line    = current_line + (is_reverse ? -1 : 1)
     let test_match      = s:find_match(line, a:patterns['test'])
     let namespace_match = s:find_match(line, a:patterns['namespace'])
 
@@ -84,13 +111,14 @@ function! test#base#nearest_test(position, patterns) abort
     if !empty(test_match) && last_indent == -1
       call add(test, filter(test_match[1:], '!empty(v:val)')[0])
       let last_indent = indent
+      let test_line   = current_line
     elseif !empty(namespace_match) && (indent < last_indent || last_indent == -1)
       call add(namespace, filter(namespace_match[1:], '!empty(v:val)')[0])
       let last_indent = indent
     endif
   endfor
 
-  return {'test': test, 'namespace': reverse(namespace)}
+  return {'test': test, 'test_line': test_line, 'namespace': reverse(namespace)}
 endfunction
 
 function! s:find_match(line, patterns) abort

--- a/autoload/test/php/phpunit.vim
+++ b/autoload/test/php/phpunit.vim
@@ -2,6 +2,16 @@ if !exists('g:test#php#phpunit#file_pattern')
   let g:test#php#phpunit#file_pattern = '\v(t|T)est\.php$'
 endif
 
+if !exists('g:test#php#phpunit#test_patterns')
+  let g:test#php#phpunit#test_patterns = {
+    \ 'test': [
+      \ '\v^\s*public function (test\w+)\(',
+      \ '\v^\s*\*\s*(\@test)'
+    \],
+    \ 'namespace': [],
+  \}
+endif
+
 function! test#php#phpunit#test_file(file) abort
   return a:file =~# g:test#php#phpunit#file_pattern
 endfunction
@@ -39,6 +49,19 @@ function! test#php#phpunit#executable() abort
 endfunction
 
 function! s:nearest_test(position) abort
-  let name = test#base#nearest_test(a:position, g:test#php#patterns)
+  " Search backward for the first public method starting with 'test' or the first '@test'
+  let name = test#base#nearest_test(a:position, g:test#php#phpunit#test_patterns)
+
+  " If we found the '@test' docblock
+  if !empty(name['test']) && '@test' == name['test'][0]
+    " Search forward for the first declared public method
+    let name = test#base#nearest_test_in_lines(
+      \ a:position['file'],
+      \ name['test_line'],
+      \ a:position['line'],
+      \ g:test#php#patterns
+    \ )
+  endif
+
   return join(name['test'])
 endfunction

--- a/spec/fixtures/phpunit/NormalTest.php
+++ b/spec/fixtures/phpunit/NormalTest.php
@@ -51,4 +51,29 @@ class NormalTest extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals(2, 4-21);
     }
+
+    public function testWithAnAnonymousClass()
+    {
+        $anonymousClass = new class() {
+            public function foo(): void
+            {
+            }
+        };
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @test
+     */
+    public function aTestMakedWithTestAnnotationAndWithAnAnonymousClass()
+    {
+        $anonymousClass = new class() {
+            public function foo(): void
+            {
+            }
+        };
+
+        $this->assertTrue(true);
+    }
 }

--- a/spec/phpunit_spec.vim
+++ b/spec/phpunit_spec.vim
@@ -52,6 +52,18 @@ describe "PHPUnit"
     Expect g:test#last_command == "phpunit --colors --filter '::aTestMarkedWithTestAnnotationAndCrazyDocblock' NormalTest.php"
   end
 
+  " it  "runs nearest test containing an anonymous class"
+  "   view +61 NormalTest.php
+  "   TestNearest
+
+  "   Expect g:test#last_command == "phpunit --colors --filter '::testWithAnAnonymousClass' NormalTest.php"
+
+  "   view +76 NormalTest.php
+  "   TestNearest
+
+  "   Expect g:test#last_command == "phpunit --colors --filter '::aTestMakedWithTestAnnotationAndWithAnAnonymousClass' NormalTest.php"
+  " end
+
   it "runs test suites"
     view NormalTest.php
     TestSuite


### PR DESCRIPTION
Hi again,

I don't think you will remember this almost three years old issue https://github.com/janko-m/vim-test/issues/74
But the fix that was proposed was actually a hack that look for the first public method instead of the actual annotation.
It works great most of the time, I mean like 99% of the time!

Unfortunately since PHP7 we are allowed to create what is called anonymous classes.
Short story long, it's a way to create a class wherever we might want, even inside a method.

I faced such a case this afternoon and realized that if my cursor is inside my test method but under the anonymous class the `:TestNearest` command will stop on the public method of the anonymous class and try to gave it as a filter to PHPUnit.

So I propose this PR to correct that unfortunate behavior.
This is a two steps job and the first one might seems dangerous, all depends on how much you trust the tests :)

I have refactor the `test#base#nearest_test` function to use a new function named `test#base#nearest_test_in_lines`.
This function does the exact same thing but is not coupled with the `position` argument and therefore can also look forward.
Plus, in the returned dictionary I added a new key `test_line` to be able to get the line where the test pattern was matched.

All tests passes, so it should not have break anything.
Feel free to ask for more information, I didn't wan to put too much things inside this message so it stays relatively short and you can find some more explanation inside the code as comments and in the commits messages.

P.S.: Once again, no updates of the README nor the doc because there is no new functionality and it should not even be consider as a change in the behavior.

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
