### PR TITLE
Remove superfluous help markup

### DIFF
--- a/doc/test.txt
+++ b/doc/test.txt
@@ -317,7 +317,6 @@ and Tmux
 >
   let test#strategy = 'vtr'
 <
-<
 VimShell ~
 
 Runs test commands in a shell written in VimScript. Requires the VimShell


### PR DESCRIPTION
This just removes an extra `<` in the help file.