### PR TITLE
Add spring bin detection to rails runner

### DIFF
--- a/autoload/test/ruby/rails.vim
+++ b/autoload/test/ruby/rails.vim
@@ -27,6 +27,8 @@ endfunction
 function! test#ruby#rails#executable() abort
   if !empty(glob('.zeus.sock'))
     return 'zeus test'
+  elseif filereadable('./bin/spring') && get(g:, 'test#ruby#use_spring_binstub', 0)
+    return './bin/spring rails test'
   elseif filereadable('./bin/rails') && get(g:, 'test#ruby#use_binstubs', 1)
     return './bin/rails test'
   elseif filereadable('Gemfile') && get(g:, 'test#ruby#bundle_exec', 1)


### PR DESCRIPTION
In #299, spring bin detection to rspec runner was added. This pr adds spring bin detection to rails runner, using the same mechanism. The [documentation](https://github.com/janko/vim-test#ruby) seems to imply that `let test#ruby#use_spring_binstub = 1` works for every ruby runner, but now the option works just for rspec runner.
