### PR TITLE
[Bugfix - #361] Handles "/** @test */" on one line

### DIFF
--- a/autoload/test/php/phpunit.vim
+++ b/autoload/test/php/phpunit.vim
@@ -3,10 +3,15 @@ if !exists('g:test#php#phpunit#file_pattern')
 endif
 
 if !exists('g:test#php#phpunit#test_patterns')
+  " Description for the tests:
+  " 1: Look for a public method which name starts with "test"
+  " 2: Look for a phpdoc tag "@test" (on a line by itself)
+  " 3: Look for a phpdoc block on one line containg the "@test" tag
   let g:test#php#phpunit#test_patterns = {
     \ 'test': [
       \ '\v^\s*public function (test\w+)\(',
-      \ '\v^\s*\*\s*(\@test)'
+      \ '\v^\s*\*\s*(\@test)',
+      \ '\v^\s*\/\*\*\s*(\@test)\s*\*\/',
     \],
     \ 'namespace': [],
   \}

--- a/spec/fixtures/phpunit/NormalTest.php
+++ b/spec/fixtures/phpunit/NormalTest.php
@@ -76,4 +76,10 @@ class NormalTest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue(true);
     }
+
+    /** @test */
+    public function aTestMarkedWithTestAnnotationOnOneLine()
+    {
+        $this->assertEquals(2, 4-21);
+    }
 }

--- a/spec/phpunit_spec.vim
+++ b/spec/phpunit_spec.vim
@@ -52,17 +52,25 @@ describe "PHPUnit"
     Expect g:test#last_command == "phpunit --colors --filter '::aTestMarkedWithTestAnnotationAndCrazyDocblock' NormalTest.php"
   end
 
-  " it  "runs nearest test containing an anonymous class"
-  "   view +61 NormalTest.php
-  "   TestNearest
+  it  "runs nearest test containing an anonymous class"
+    view +61 NormalTest.php
+    TestNearest
 
-  "   Expect g:test#last_command == "phpunit --colors --filter '::testWithAnAnonymousClass' NormalTest.php"
+    Expect g:test#last_command == "phpunit --colors --filter '::testWithAnAnonymousClass' NormalTest.php"
 
-  "   view +76 NormalTest.php
-  "   TestNearest
+    view +76 NormalTest.php
+    TestNearest
 
-  "   Expect g:test#last_command == "phpunit --colors --filter '::aTestMakedWithTestAnnotationAndWithAnAnonymousClass' NormalTest.php"
-  " end
+    Expect g:test#last_command == "phpunit --colors --filter '::aTestMakedWithTestAnnotationAndWithAnAnonymousClass' NormalTest.php"
+  end
+
+  " Fix for: https://github.com/janko/vim-test/issues/361
+  it "runs nearest test with a one line @test annotation"
+    view +83 NormalTest.php
+    TestNearest
+
+    Expect g:test#last_command == "phpunit --colors --filter '::aTestMarkedWithTestAnnotationOnOneLine' NormalTest.php"
+  end
 
   it "runs test suites"
     view NormalTest.php


### PR DESCRIPTION
The fix for the ticket #361 
It was only missing on test for this case.

For phpunit the conditions to find a test was a public method with a name starting by "test".
Or the public method right after a phpdoc block containing the tag "@test", in the form:
```php
/**
* @test
*/
```

I just added a new test to take the following case into account:
```php
/** @test */
```

I'm not use to this style so I don't know if it's tolerated to have multiple tags one the same line...
For now it only works for this specific case.
The reason behind that is that I don't think it's a good idea to have multiple tags on the same line, I'm not event sure it's tolerated in phpdoc.
Plus, we got a great tool called Vim which provides folding :D

I added a new test to confirm the error before fixing it.
And I realized I had commented the ones from the previous commit...
So I put them back on.

- [x] Add fixtures and spec when implementing or updating a test runner
