### PR TITLE
Conditionally prefix pytest command with pipenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,11 @@ the first available will be chosen, but you can force a specific one:
 let test#python#runner = 'pytest'
 " Runners available are 'pytest', 'nose', 'nose2', 'djangotest', 'djangonose' and Python's built-in 'unittest'
 ```
+
+The pytest runner optionally supports [pipenv](https://github.com/pypa/pipenv).
+If you have a `Pipfile`, it will use `pipenv run pytest` instead of just
+`pytest`.
+
 #### Java
 
 For the same reason as Python, runner detection works the same for Java. To

--- a/autoload/test/python/pytest.vim
+++ b/autoload/test/python/pytest.vim
@@ -38,10 +38,16 @@ function! test#python#pytest#build_args(args) abort
 endfunction
 
 function! test#python#pytest#executable() abort
+  let pipenv_prefix = ""
+
+  if filereadable("Pipfile")
+    let pipenv_prefix = "pipenv run "
+  endif
+
   if executable("py.test") && !executable("pytest")
-    return "py.test"
+    return pipenv_prefix . "py.test"
   else
-    return "pytest"
+    return pipenv_prefix . "pytest"
   endif
 endfunction
 

--- a/spec/fixtures/pytest_pipenv/Pipfile
+++ b/spec/fixtures/pytest_pipenv/Pipfile
@@ -1,0 +1,7 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[dev-packages]
+pytest = "*"

--- a/spec/fixtures/pytest_pipenv/test_class.py
+++ b/spec/fixtures/pytest_pipenv/test_class.py
@@ -1,0 +1,3 @@
+class TestNumbers:
+    def test_numbers(self):
+        assert 1 == 1

--- a/spec/pytest_pipenv_spec.vim
+++ b/spec/pytest_pipenv_spec.vim
@@ -1,0 +1,36 @@
+source spec/support/helpers.vim
+
+describe "PyTest with Pipenv"
+
+  before
+    let g:test#python#runner = 'pytest'
+    cd spec/fixtures/pytest_pipenv
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "runs nearest tests"
+    view +1 test_class.py
+    TestNearest
+
+    Expect g:test#last_command == 'pipenv run pytest test_class.py::TestNumbers'
+  end
+
+  it "runs file tests"
+    view test_class.py
+    TestFile
+
+    Expect g:test#last_command == 'pipenv run pytest test_class.py'
+  end
+
+  it "runs test suites"
+    view test_class.py
+    TestSuite
+
+    Expect g:test#last_command == 'pipenv run pytest'
+  end
+
+end


### PR DESCRIPTION
[pipenv](https://github.com/pypa/pipenv) requires you to run commands with "pipenv run ...". This change prefixes the command if it finds a Pipfile.

I wasn't quite sure how to test this, so let me know if you'd like it done a different way. Also, `pipenv` could work with any of the python runners, but I just added it to the one we use.

Make sure these boxes are checked before submitting your pull request:

- [X] Add fixtures and spec when implementing or updating a test runner
- [X] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt` **I didn't think this needs an update but let me know if you think I should add the same blurb in here somewhere.**
