### PR TITLE
allow a global cli option to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ endif
 
 ### Quickfix Strategies
 
-If you want your test results to appear in the quickfix window, use one of the 
+If you want your test results to appear in the quickfix window, use one of the
 following strategies:
 
  * Make
@@ -148,15 +148,15 @@ following strategies:
  * Dispatch.vim
 
 Regardless of which you pick, it's recommended you have Dispatch.vim installed as the
-strategies will automatically use it to determine the correct compiler, ensuring the 
+strategies will automatically use it to determine the correct compiler, ensuring the
 test output is correctly parsed for the quickfix window.
 
-As Dispatch.vim just determines the compiler, you need to make sure the Vim distribution 
-or a plugin has a corresponding compiler for your test runner, or you may need to write a 
+As Dispatch.vim just determines the compiler, you need to make sure the Vim distribution
+or a plugin has a corresponding compiler for your test runner, or you may need to write a
 compiler plugin.
 
-If the test command prefix doesn't match the compiler's `makeprg` then use the 
-`g:dispatch_compiler` variable. For example if your test command was `./vendor/bin/phpunit` 
+If the test command prefix doesn't match the compiler's `makeprg` then use the
+`g:dispatch_compiler` variable. For example if your test command was `./vendor/bin/phpunit`
 but you wanted to use the phpunit2 compiler:
 
 ```vim
@@ -250,6 +250,16 @@ let test#ruby#rspec#options = {
   \ 'nearest': '--backtrace',
   \ 'file':    '--format documentation',
   \ 'suite':   '--tag ~slow',
+\}
+```
+
+You can also specify a global approach along with the granular options for the
+specified test runner:
+
+```vim
+let test#ruby#rspec#options = {
+  \ 'all':   '--backtrace',
+  \ 'suite': '--tag ~slow',
 \}
 ```
 

--- a/autoload/test/base.vim
+++ b/autoload/test/base.vim
@@ -11,7 +11,7 @@ function! test#base#options(runner, ...) abort
   if empty(a:000) && type(options) == type('')
     return split(options)
   elseif !empty(a:000) && type(options) == type({})
-    return split(get(options, a:000[0], ''))
+    return split(get(options, 'all', '')) + split(get(options, a:000[0], ''))
   else
     return []
   endif

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -422,6 +422,16 @@ Or, if you prefer more granular approach, you can do
     \ 'suite':   '--tag ~slow',
   \}
 <
+You can also specify a global option for the test runner to work alongside the
+granular options. Here, all rspec tests will run with the --format documentation
+option and any suite granularities will be run with the --tag ~slow option as
+well
+>
+  let g:test#ruby#rspec#options = {
+    \ 'all':   '--format documentation',
+    \ 'suite': '--tag ~slow',
+  \}
+<
 If you want to manually configure a test runner's executable, you can do
 >
   let g:test#ruby#rspec#executable = 'foreman run rspec'

--- a/spec/options_spec.vim
+++ b/spec/options_spec.vim
@@ -78,6 +78,23 @@ describe 'Options'
       TestSuite
       Expect g:test#last_command == 'rspec'
     end
+
+    it "allows a global option to be set along with specific granularities"
+      let g:test#ruby#rspec#options = {
+        \ 'all':  '--foo bar',
+        \ 'file': '--baz',
+      \}
+      new foo_spec.rb
+
+      TestNearest
+      Expect g:test#last_command == 'rspec --foo bar foo_spec.rb:1'
+
+      TestSuite
+      Expect g:test#last_command == 'rspec --foo bar'
+
+      TestFile
+      Expect g:test#last_command == 'rspec --foo bar --baz foo_spec.rb'
+    end
   end
 
 end


### PR DESCRIPTION
references #375 

this will allow users to specify a global option to be set alongside
any granular options for test runners

Make sure these boxes are checked before submitting your pull request:

- [X] Add fixtures and spec when implementing or updating a test runner
-  [X] Update the README accordingly
- [X] Update the Vim documentation in `doc/test.txt`
