### PR TITLE
Feature/kitty strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ let test#strategy = "dispatch"
 | **[AsyncRun]**                  | `asyncrun`                       | Runs test commands asynchronosuly using new APIs in Vim 8 and NeoVim.            |
 | **Terminal.app**                | `terminal`                       | Sends test commands to Terminal (useful in MacVim GUI).                          |
 | **iTerm2.app**                  | `iterm`                          | Sends test commands to iTerm2 >= 2.9 (useful in MacVim GUI).                     |
+| **Kitty**                       | `kitty`                          | Sends test commands to Kitty terminal.                                           |
 
 You can also set up strategies per granularity:
 
@@ -136,6 +137,24 @@ if has('nvim')
   tmap <C-o> <C-\><C-n>
 endif
 ```
+
+### Kitty strategy setup
+
+Before you can run tests in a kitty terminal window using the kitty strategy,
+please make sure:
+
+- you start kitty setting up remote control and specifying a socket for kitty
+  to listen to, like this:
+
+    ```
+    > kitty -o allow_remote_control=yes --listen-on unix:/tmp/mykitty
+    ```
+
+- you export an environment variable `$KITTY_LISTEN_ON` with the same socket, like:
+
+    ```
+    export KITTY_LISTEN_ON=/tmp/mykitty
+    ```
 
 ### Quickfix Strategies
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ let test#strategy = "dispatch"
 | **[AsyncRun]**                  | `asyncrun`                       | Runs test commands asynchronosuly using new APIs in Vim 8 and NeoVim.            |
 | **Terminal.app**                | `terminal`                       | Sends test commands to Terminal (useful in MacVim GUI).                          |
 | **iTerm2.app**                  | `iterm`                          | Sends test commands to iTerm2 >= 2.9 (useful in MacVim GUI).                     |
-| **Kitty**                       | `kitty`                          | Sends test commands to Kitty terminal.                                           |
+| **[Kitty]**                     | `kitty`                          | Sends test commands to Kitty terminal.                                           |
 
 You can also set up strategies per granularity:
 
@@ -519,3 +519,4 @@ Copyright © Janko Marohnić. Distributed under the same terms as Vim itself. Se
 [MakeGreen]: https://github.com/reinh/vim-makegreen
 [M]: http://github.com/qrush/m
 [projectionist.vim]: https://github.com/tpope/vim-projectionist
+[Kitty]: https://github.com/kovidgoyal/kitty

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -104,6 +104,10 @@ function! test#strategy#iterm(cmd) abort
   call s:execute_script('osx_iterm', cmd)
 endfunction
 
+function! test#strategy#kitty(cmd) abort
+  let cmd = join(['cd ' . shellescape(getcwd()), s:pretty_command(a:cmd)], '; ')
+  call s:execute_script('kitty_runner', cmd)
+endfunction
 
 function! s:execute_with_compiler(cmd, script) abort
   try

--- a/bin/kitty_runner
+++ b/bin/kitty_runner
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+if [[ `kitty @ ls | grep -c '            "title": "vim-test-output'` -eq 0 ]];
+then
+  kitty @ --to $KITTY_LISTEN_ON new-window --keep-focus --title "vim-test-output" $SHELL
+fi
+
+kitty @ --to $KITTY_LISTEN_ON send-text --match title:"vim-test-output" "$1\x0d"
+

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -334,7 +334,31 @@ isn't that nice).
   " or
   let test#strategy = 'iterm'
 <
+Kitty ~
 
+If you ewant to run commands in a Kitty terminal window you can use this
+strategy.
+
+Please make sure:
+
+- you start kitty setting up remote control and specifying a socket for kitty
+  to listen to, like this:
+
+>
+  > kitty -o allow_remote_control=yes --listen-on unix:/tmp/mykitty
+<
+
+- you export an environment variable `$KITTY_LISTEN_ON` with the same socket, like:
+
+>
+  export KITTY_LISTEN_ON=/tmp/mykitty
+<
+
+You can then use this strategy this way:
+
+>
+  let test#strategy = 'kitty'
+<
 
 QUICKFIX STRATEGIES                               *test-quickfix-strategies*
 


### PR DESCRIPTION
Hi @janko , I'm working on a [kitty terminal](https://github.com/kovidgoyal/kitty) strategy for vim-test. This first working version uses the same approach of the iterm2 strategy; it also requires the user to set an environment variable and launch kitty with a listen socket. Let me know what you think.

Keep up the great work!