### PR TITLE
Add support for the Delve test runner for Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ runners are supported:
 | **Elixir**     | ESpec, ExUnit                                                                               | `espec`, `exunit`                                                                                               |
 | **Elm**        | elm-test                                                                                    | `elmtest`                                                                                                       |
 | **Erlang**     | CommonTest                                                                                  | `commontest`                                                                                                    |
-| **Go**         | Ginkgo, Go, Rich-Go                                                                         | `ginkgo`, `gotest`, `richgo`                                                                                    |
+| **Go**         | Ginkgo, Go, Rich-Go, Delve                                                                  | `ginkgo`, `gotest`, `richgo`, `delve`                                                                           |
 | **Java**       | Maven, Gradle                                                                               | `maventest`, `gradletest`                                                                                       |
 | **JavaScript** | Ava, Cucumber.js, Intern, Jasmine, Jest, ReactScripts, Karma, Lab, Mocha, TAP, WebdriverIO  | `ava`, `cucumberjs`, `intern`, `jasmine`, `jest`, `reactscripts`, `karma`, `lab`, `mocha`, `tap`, `webdriverio` |
 | **Lua**        | Busted                                                                                      | `busted`                                                                                                        |
@@ -372,8 +372,12 @@ force a specific runner:
 
 ``` vim
 let test#go#runner = 'ginkgo'
-" Runners available are 'gotest', 'ginkgo', 'richgo'
+" Runners available are 'gotest', 'ginkgo', 'richgo', 'delve'
 ```
+
+If `delve` is selected and [vim-delve](https://github.com/sebdah/vim-delve) is
+in use, breakpoints and tracepoints that have been marked with vim-delve will
+be included.
 
 #### Ruby
 

--- a/README.md
+++ b/README.md
@@ -375,6 +375,19 @@ let test#go#runner = 'ginkgo'
 " Runners available are 'gotest', 'ginkgo', 'richgo', 'delve'
 ```
 
+You can also configure the `delve` runner with a different key mapping
+alongside another:
+
+```vim
+nmap <silent> t<C-n> :TestNearest<CR>
+function! DebugNearest()
+  let g:test#go#runner = 'delve'
+  TestNearest
+  unlet g:test#go#runner
+endfunction
+nmap <silent> t<C-d> :call DebugNearest()<CR>
+```
+
 If `delve` is selected and [vim-delve](https://github.com/sebdah/vim-delve) is
 in use, breakpoints and tracepoints that have been marked with vim-delve will
 be included.

--- a/autoload/test.vim
+++ b/autoload/test.vim
@@ -18,7 +18,7 @@ function! test#run(type, arguments) abort
 
   let args = test#base#build_position(runner, a:type, position)
   let args = a:arguments + args
-  let args = test#base#options(runner, a:type) + args
+  let args = test#base#options(runner, args, a:type)
 
   if type(get(g:, 'test#strategy')) == type({})
     let strategy = get(g:test#strategy, a:type)
@@ -77,7 +77,7 @@ function! test#execute(runner, args, ...) abort
   endif
 
   let args = a:args
-  let args = test#base#options(a:runner) + args
+  let args = test#base#options(a:runner, args)
   call filter(args, '!empty(v:val)')
 
   let executable = test#base#executable(a:runner)

--- a/autoload/test/base.vim
+++ b/autoload/test/base.vim
@@ -6,14 +6,19 @@ function! test#base#build_position(runner, type, position) abort
   return test#{a:runner}#build_position(a:type, a:position)
 endfunction
 
-function! test#base#options(runner, ...) abort
+function! test#base#options(runner, args, ...) abort
   let options = get(g:, 'test#'.a:runner.'#options')
   if empty(a:000) && type(options) == type('')
-    return split(options)
+    let options = split(options)
   elseif !empty(a:000) && type(options) == type({})
-    return split(get(options, 'all', '')) + split(get(options, a:000[0], ''))
+    let options = split(get(options, 'all', '')) + split(get(options, a:000[0], ''))
   else
-    return []
+    let options = []
+  endif
+  if exists('*test#'.a:runner.'#build_options')
+    return test#{a:runner}#build_options(a:args, options)
+  else
+    return options + a:args
   endif
 endfunction
 

--- a/autoload/test/go/delve.vim
+++ b/autoload/test/go/delve.vim
@@ -1,0 +1,53 @@
+if !exists('g:test#go#delve#file_pattern')
+  let g:test#go#delve#file_pattern = g:test#go#gotest#file_pattern
+endif
+
+function! test#go#delve#test_file(file) abort
+  return test#go#test_file('delve', g:test#go#delve#file_pattern, a:file)
+endfunction
+
+function! test#go#delve#build_position(type, position) abort
+  if a:type ==# 'suite'
+    return ['./...']
+  else
+    let path = './'.fnamemodify(a:position['file'], ':h')
+
+    if a:type ==# 'file'
+      return path ==# './.' ? [] : [path . '/...']
+    elseif a:type ==# 'nearest'
+      let name = s:nearest_test(a:position)
+      return empty(name) ? [] : [path, '-test.run '.shellescape(name.'$', 1)]
+    endif
+  endif
+endfunction
+
+function! test#go#delve#build_options(args, options) abort
+  return a:args + a:options
+endfunction
+
+function! test#go#delve#build_args(args) abort
+  let args = a:args
+
+  " Optionally, if the vim-delve plugin is installed this will also include
+  " any breakpoints, tracepoints, etc that have been marked in vim into the
+  " state of delve when it runs.
+  if exists('*delve#getInitInstructions')
+    let delve_init_instructions = delve#getInitInstructions()
+    if len(delve_init_instructions) > 0
+      let temp_file = tempname()
+      call writefile(delve_init_instructions, temp_file)
+      let args = ['--init='.temp_file] + a:args
+    endif
+  endif
+
+  return args
+endfunction
+
+function! test#go#delve#executable() abort
+  return 'dlv test'
+endfunction
+
+function! s:nearest_test(position) abort
+  let name = test#base#nearest_test(a:position, g:test#go#patterns)
+  return join(name['test'])
+endfunction

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -160,6 +160,9 @@ In all commands [args] are forwarded to the underlying test runner.
                                                 *test-:RichGo*
 :RichGo [args]               Uses the `richgo` `test` command.
 
+                                                *test-:Delve*
+:Delve [args]                Uses the `dlv` `test` command.
+
                                                 *test-:CargoTest*
 :CargoTest [args]            Uses the `cargo` `test` command.
 

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -12,7 +12,7 @@ let g:test#default_runners = {
   \ 'Elixir':     ['ExUnit', 'ESpec'],
   \ 'Elm':        ['ElmTest'],
   \ 'Erlang':     ['CommonTest'],
-  \ 'Go':         ['GoTest', 'Ginkgo', 'RichGo'],
+  \ 'Go':         ['GoTest', 'Ginkgo', 'RichGo', 'Delve'],
   \ 'Rust':       ['CargoTest'],
   \ 'Clojure':    ['FireplaceTest'],
   \ 'CSharp':     ['Xunit', 'DotnetTest'],

--- a/spec/delve_spec.vim
+++ b/spec/delve_spec.vim
@@ -1,0 +1,71 @@
+source spec/support/helpers.vim
+
+describe "Delve"
+
+  before
+    let g:test#go#runner = "delve"
+    cd spec/fixtures/delve
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "runs nearest tests"
+    view +5 normal_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'dlv test ./. -test.run ''TestNumbers$'''
+  end
+
+  it "runs nearest tests in subdirectory"
+    view +5 mypackage/normal_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'dlv test ./mypackage -test.run ''TestNumbers$'''
+  end
+
+  it "runs file test if nearest test couldn't be found"
+    view +1 normal_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'dlv test'
+  end
+
+  it "runs file tests"
+    view normal_test.go
+    TestFile
+
+    Expect g:test#last_command == 'dlv test'
+  end
+
+  it "runs tests in subdirectory"
+    view mypackage/normal_test.go
+    TestFile
+
+    Expect g:test#last_command == 'dlv test ./mypackage/...'
+  end
+
+  it "runs test suites"
+    view normal_test.go
+    TestSuite
+
+    Expect g:test#last_command == 'dlv test ./...'
+  end
+
+  describe "when options are defined"
+    before
+      let g:test#go#delve#options = '-test.v'
+    end
+    after
+      unlet g:test#go#delve#options
+    end
+    it "appends options to the end"
+      view normal_test.go
+      TestSuite
+
+      Expect g:test#last_command == 'dlv test ./... -test.v'
+    end
+  end
+end

--- a/spec/fixtures/delve/mypackage/normal_test.go
+++ b/spec/fixtures/delve/mypackage/normal_test.go
@@ -1,0 +1,7 @@
+package mypackage
+
+import "testing"
+
+func TestNumbers(*testing.T) {
+	// assertions
+}

--- a/spec/fixtures/delve/normal_test.go
+++ b/spec/fixtures/delve/normal_test.go
@@ -1,0 +1,7 @@
+package mypackage
+
+import "testing"
+
+func TestNumbers(*testing.T) {
+    // assertions
+}

--- a/spec/go_runner_spec.vim
+++ b/spec/go_runner_spec.vim
@@ -27,11 +27,12 @@ describe "Go Runner"
 
   describe "when test#go#runner is set"
     it "should respect test#go#runner"
-      for runner in ["ginkgo", "gotest", "richgo"]
+      for runner in ["ginkgo", "gotest", "richgo", "delve"]
         let g:test#go#runner = runner
         Expect test#determine_runner("ginkgo/normal_test.go") == 'go#'.runner
         Expect test#determine_runner("gotest/normal_test.go") == 'go#'.runner
         Expect test#determine_runner("richgo/normal_test.go") == 'go#'.runner
+        Expect test#determine_runner("delve/normal_test.go") == 'go#'.runner
       endfor
     end
   end


### PR DESCRIPTION
# What
Add support for the Delve test runner for Go that will run `dlv test`
for the identified tests and include breakpoints and tracepoints if
`vim-delve` is also in use.

# Why
`vim-test` makes it really easy to run tests in Go programs, but it's
much harder to debug tests. In other languages like Ruby it's relatively
easy because their debuggers are inserted into their normal application
runtimes, but with Go to debug requires executing a different
application with unique parameters. This makes debugging Go tests as
simple as running them, all with vim-test.

Additionally, if vim-delve is in use a user can select breakpoints and
tracepoints within vim, and this change includes pulling in that list of
instructions and includes them in the init setup of dlv. Use of this component
is optional and you can quite reliably use dlv test without passing
that init through by defining breakpoints at the dlv console.

# Note
Part of this change is dependent on sebdah/vim-delve#34.

One change was made to options to allow a test runner to modify the
options before including them into the cmd to be executed. The delve
command is a little odd in that it specifies the package part of the
build position before all other flags.

# Checklist
- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`