### PR TITLE
Fix options being appended in delve runner

### DIFF
--- a/autoload/test/go/delve.vim
+++ b/autoload/test/go/delve.vim
@@ -16,13 +16,17 @@ function! test#go#delve#build_position(type, position) abort
       return path ==# './.' ? [] : [path . '/...']
     elseif a:type ==# 'nearest'
       let name = s:nearest_test(a:position)
-      return empty(name) ? [] : [path, '-test.run '.shellescape(name.'$', 1)]
+      return empty(name) ? [] : [path, '--', '-test.run '.shellescape(name.'$', 1)]
     endif
   endif
 endfunction
 
 function! test#go#delve#build_options(args, options) abort
-  return a:args + a:options
+  let args = a:args
+  if len(a:options) > 0 && index(args, '--') == -1
+    let args = args + ['--']
+  endif
+  return args + a:options
 endfunction
 
 function! test#go#delve#build_args(args) abort

--- a/spec/delve_spec.vim
+++ b/spec/delve_spec.vim
@@ -16,14 +16,14 @@ describe "Delve"
     view +5 normal_test.go
     TestNearest
 
-    Expect g:test#last_command == 'dlv test ./. -test.run ''TestNumbers$'''
+    Expect g:test#last_command == 'dlv test ./. -- -test.run ''TestNumbers$'''
   end
 
   it "runs nearest tests in subdirectory"
     view +5 mypackage/normal_test.go
     TestNearest
 
-    Expect g:test#last_command == 'dlv test ./mypackage -test.run ''TestNumbers$'''
+    Expect g:test#last_command == 'dlv test ./mypackage -- -test.run ''TestNumbers$'''
   end
 
   it "runs file test if nearest test couldn't be found"
@@ -61,11 +61,17 @@ describe "Delve"
     after
       unlet g:test#go#delve#options
     end
-    it "appends options to the end"
+    it "appends options to the end in a suite test"
       view normal_test.go
       TestSuite
 
-      Expect g:test#last_command == 'dlv test ./... -test.v'
+      Expect g:test#last_command == 'dlv test ./... -- -test.v'
+    end
+    it "appends options to the end in a nearest test"
+      view +5 normal_test.go
+      TestNearest
+
+      Expect g:test#last_command == 'dlv test ./. -- -test.run ''TestNumbers$'' -test.v'
     end
   end
 end


### PR DESCRIPTION
# What
Insert a `--` in the dlv test command between the package name and where
test options are supplied.

# Why
The `--` is necessary to tell the dlv test command where options for go
test can be supplied vs where the package list start and ends.

When I originally developed the delve runner I had included a `--` and
then removed it thinking it was unnecessary just before I opened the PR
(#385). The test scenarios I'd coded didn't pickup on the options now
being ignored.

Sorry @janko, I didn't pickup on it fast enough before it was merged!

# Checklist
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [ ] ~Update the README accordingly~
- [ ] ~Update the Vim documentation in `doc/test.txt`~
