### PR TITLE
Recognize `Task` as well as `void` return type

### DIFF
--- a/autoload/test/csharp.vim
+++ b/autoload/test/csharp.vim
@@ -1,5 +1,5 @@
 let g:test#csharp#patterns = {
-  \ 'test':      ['\v^\s*public void (\w+)', '\v^\s*public async void (\w+)'],
+  \ 'test':      ['\v^\s*public void (\w+)', '\v^\s*public async void (\w+)', '\v^\s*public async Task (\w+)'],
   \ 'namespace': ['\v^\s*public class (\w+)', '\v^\s*namespace ((\w|\.)+)'],
 \}
 

--- a/spec/dotnet_spec.vim
+++ b/spec/dotnet_spec.vim
@@ -34,6 +34,12 @@ describe "DotnetTest"
     let actual = s:remove_path(g:test#last_command)
     Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName\~Namespace.Tests.Test'
 
+    view +20 Tests.cs
+    TestNearest
+
+    let actual = s:remove_path(g:test#last_command)
+    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName\~Namespace.Tests.TestAsyncWithTaskReturn'
+
   end
 
   it "runs file test if nearest test couldn't be found"

--- a/spec/fixtures/dotnet/Tests.cs
+++ b/spec/fixtures/dotnet/Tests.cs
@@ -13,5 +13,11 @@ namespace Namespace
         {
             Assert.Equal(true, false);
         }
+
+        [Fact]
+        public async Task TestAsyncWithTaskReturn()
+        {
+            Assert.Equal(true, false);
+        }
     }
 }


### PR DESCRIPTION
It's not uncommon to have tests have a `Task` return type when they're
async, instead of void. With this patch, `:TestNearest` works as
intended when the cursor is inside a test like this:

```
[Fact]
public async Task MyTest()
{
    Assert.True(true)
}
```

Before this patch, `:TestNearest` would test the whole file instead.

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
