### PR TITLE
Support `spec` files as well with sbt

### DIFF
--- a/autoload/test/scala/sbttest.vim
+++ b/autoload/test/scala/sbttest.vim
@@ -1,5 +1,5 @@
 if !exists('g:test#scala#sbttest#file_pattern')
-  let g:test#scala#sbttest#file_pattern = '\v^(.*test.*|.*suite.*)\c\.scala$'
+  let g:test#scala#sbttest#file_pattern = '\v^(.*test.*|.*suite.*|.*spec.*)\c\.scala$'
 endif
 
 " Returns true if the given file belongs to your test runner


### PR DESCRIPTION
I could not figure out at all, why my scala test files were always run with `bloop`. I think sbt should also be allowed to run fields with `Spec` in the name