### PR TITLE
Add haskell / stack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ runners are supported:
 | **Elm**        | elm-test                                                                                    | `elmtest`                                                                                                       |
 | **Erlang**     | CommonTest, EUnit                                                                           | `commontest`, `eunit`                                                                                           |
 | **Go**         | Ginkgo, Go, Rich-Go, Delve                                                                  | `ginkgo`, `gotest`, `richgo`, `delve`                                                                           |
+| **Haskell**    | stack                                                                                       | `stacktest`                                                                                                     | 
 | **Java**       | Maven, Gradle                                                                               | `maventest`, `gradletest`                                                                                       |
 | **JavaScript** | Ava, Cucumber.js, Intern, Jasmine, Jest, ReactScripts, Karma, Lab, Mocha, TAP, WebdriverIO  | `ava`, `cucumberjs`, `intern`, `jasmine`, `jest`, `reactscripts`, `karma`, `lab`, `mocha`, `tap`, `webdriverio` |
 | **Lua**        | Busted                                                                                      | `busted`                                                                                                        |
@@ -441,6 +442,10 @@ let test#ruby#use_spring_binstub = 1
 #### JavaScript
 
 Test runner detection for JavaScript works by checking which runner is listed in the package.json dependencies. If you have globally installed the runner make sure it's also listed in the dependencies.
+
+#### Haskell
+
+The `stackTest` runner currently supports running tests in Stack projects with the (HSpec)[http://hackage.haskell.org/package/hspec] framework.
 
 ## Autocommands
 

--- a/autoload/test/haskell.vim
+++ b/autoload/test/haskell.vim
@@ -1,0 +1,15 @@
+let test#haskell#patterns = {
+  \ 'test':      ['\v\s*describe\s"(.*)"', '\v^\s*it\s"(.*)".*$'],
+  \ 'namespace': [],
+\}
+
+function! test#haskell#test_file(runner, file_pattern, file) abort
+  let current_file = fnamemodify(a:file, ':t')
+  if current_file =~? a:file_pattern
+    if exists('g:test#haskell#runner')
+      return a:runner == g:test#haskell#runner
+    else "default runner
+      return a:runner == 'stacktest'
+    endif
+  endif
+endfunction

--- a/autoload/test/haskell/stacktest.vim
+++ b/autoload/test/haskell/stacktest.vim
@@ -1,0 +1,41 @@
+if !exists('g:test#haskell#stacktest#file_pattern')
+  let g:test#haskell#stacktest#file_pattern = '\v^(.*spec.*)\c\.hs$'
+endif
+
+" Returns true if the given file belongs to your test runner
+function! test#haskell#stacktest#test_file(file) abort
+  return test#haskell#test_file('stacktest', g:test#haskell#stacktest#file_pattern, a:file)
+endfunction
+
+" Returns test runner's arguments which will run the current file and/or line
+function! test#haskell#stacktest#build_position(type, position) abort
+  let filename = fnamemodify(a:position['file'], ':t:r')
+
+  if a:type ==# 'nearest'
+    let name = s:nearest_test(a:position)
+    let s:module_name = substitute(filename, "Spec", "", "")
+    if !empty(name)
+      return ["test " . "--test-arguments '-m \"" . name . "\"'"]
+    else
+      return ["test " . "--test-arguments '-m \"" . s:module_name . "\"'"]
+    endif
+  elseif a:type ==# 'file'
+    let s:module_name = substitute(filename, "Spec", "", "")
+    return ["test " . "--test-arguments '-m \"" . s:module_name . "\"'"]
+  else
+    return ['"test"']
+  endif
+endfunction
+
+function! test#haskell#stacktest#build_args(args) abort
+  return a:args
+endfunction
+
+function! test#haskell#stacktest#executable() abort
+  return 'stack'
+endfunction
+
+function! s:nearest_test(position) abort
+  let name = test#base#nearest_test(a:position, g:test#haskell#patterns)
+  return escape(escape(join(name['test'], ""), '"'), "'")
+endfunction

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -236,6 +236,9 @@ In all commands [args] are forwarded to the underlying test runner.
                                                 *test-:SwiftPM*
 :SwiftPM [args]              Uses the `swift test` command.
 
+                                                *test-:StackTest*
+:StackTest [args]            Uses the `stack test` command.
+
 
 STRATEGIES                                      *test-strategies*
 

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -25,6 +25,7 @@ let g:test#default_runners = {
   \ 'Racket':     ['RackUnit'],
   \ 'Java':       ['MavenTest', 'GradleTest'],
   \ 'Scala':      ['SbtTest', 'BloopTest'],
+  \ 'Haskell':    ['StackTest'],
   \ 'Crystal':    ['CrystalSpec'],
 \}
 

--- a/spec/fixtures/stack/FixtureSpec.hs
+++ b/spec/fixtures/stack/FixtureSpec.hs
@@ -1,0 +1,16 @@
+module FixtureSpec where
+import           Test.Hspec
+import           Test.QuickCheck
+import           Control.Exception              ( evaluate )
+
+spec :: Spec
+spec = describe "Prelude.head" $ do
+  it "returns the first element of a list" $ head [23 ..] `shouldBe` (24 :: Int)
+
+  it "returns the first element of an *arbitrary* list" $ property $ \x xs ->
+    head (x : xs) == (x :: Int)
+
+  it "throws an exception if used with an empty list"
+    $             evaluate (head [])
+    `shouldThrow` anyException
+

--- a/spec/stacktest_spec.vim
+++ b/spec/stacktest_spec.vim
@@ -1,0 +1,35 @@
+source spec/support/helpers.vim
+
+describe "STACK"
+
+  before
+    cd spec/fixtures/stack
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "runs when filename matches *Spec.hs"
+    view FixtureSpec.hs
+    TestFile
+
+    Expect g:test#last_command == "stack test --test-arguments '-m \"Fixture\"'"
+  end
+
+  it "runs nearest tests"
+    view +9 FixtureSpec.hs
+    TestNearest
+
+    Expect g:test#last_command == "stack test --test-arguments '-m \"returns the first element of a list\"'"
+  end
+
+  it "runs all test in a suite"
+    view FixtureSpec.hs
+    TestSuite
+
+    Expect g:test#last_command == 'stack "test"'
+  end
+
+end


### PR DESCRIPTION
Hey, this adds basic support for running tests with stack in haskell.
Please help me out with syntax or anything regarding the vim scripting, as I am pretty new to that.

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
