### PR TITLE
Add support for more scalatest styles

### DIFF
--- a/autoload/test/scala.vim
+++ b/autoload/test/scala.vim
@@ -1,5 +1,5 @@
 let test#scala#patterns = {
-  \ 'test':      ['\v^\s*test\((.*)\)', '\v^\s*(".*") in.*$'],
+  \ 'test':      ['\v^\s*test\((.*)\)', '\v^\s*("[^"]*") in.*$', '\v^\s*%(it|"[^"]*")\sshould\s("[^"]*")'],
   \ 'namespace': [],
 \}
 

--- a/spec/blooptest_spec.vim
+++ b/spec/blooptest_spec.vim
@@ -20,6 +20,13 @@ describe "Bloop"
     Expect g:test#last_command == 'bloop test bloop_project -o "*FixtureTest"'
   end
 
+  it "runs when filename matches *Spec.scala"
+    view FixtureSpec.scala
+    TestFile
+
+    Expect g:test#last_command == 'bloop test bloop_project -o "*FixtureSpec"'
+  end
+
   it "runs when filename matches *Suite.scala"
     view FixtureSuite.scala
     TestFile

--- a/spec/blooptest_spec.vim
+++ b/spec/blooptest_spec.vim
@@ -62,11 +62,32 @@ describe "Bloop"
     Expect g:test#last_command == 'bloop test bloop_project -o "*whatever_suite_smth"'
   end
 
-  it "runs nearest tests"
+  it "runs nearest tests for FunSuite"
     view +32 FixtureTestSuite.scala
     TestNearest
 
     Expect g:test#last_command == 'bloop test bloop_project -o "*FixtureTestSuite" -- -z "Assert ''add'' works for Double and returns Double"'
+  end
+
+  it "runs nearest tests for FlatSpec style"
+    view +14 FixtureSpec.scala
+    TestNearest
+
+    Expect g:test#last_command == 'bloop test bloop_project -o "*FixtureSpec" -- -z "throw NoSuchElementException if an empty stack is popped"'
+  end
+
+  it "runs nearest tests for first test in FlatSpec style"
+    view +6 FixtureSpec.scala
+    TestNearest
+
+    Expect g:test#last_command == 'bloop test bloop_project -o "*FixtureSpec" -- -z "pop values in last-in-first-out order"'
+  end
+
+  it "runs nearest tests for first test in WordSpec style"
+    view +7 WordSpec.scala
+    TestNearest
+
+    Expect g:test#last_command == 'bloop test bloop_project -o "*WordSpec" -- -z "have size 0"'
   end
 
   it "runs a suite"

--- a/spec/fixtures/sbt/FixtureSpec.scala
+++ b/spec/fixtures/sbt/FixtureSpec.scala
@@ -1,0 +1,20 @@
+import collection.mutable.Stack
+import org.scalatest._
+
+class ExampleSpec extends FlatSpec with Matchers {
+
+  "A Stack" should "pop values in last-in-first-out order" in {
+    val stack = new Stack[Int]
+    stack.push(1)
+    stack.push(2)
+    stack.pop() should be (2)
+    stack.pop() should be (1)
+  }
+
+  it should "throw NoSuchElementException if an empty stack is popped" in {
+    val emptyStack = new Stack[Int]
+    a [NoSuchElementException] should be thrownBy {
+      emptyStack.pop()
+    } 
+  }
+}

--- a/spec/fixtures/sbt/WordSpec.scala
+++ b/spec/fixtures/sbt/WordSpec.scala
@@ -1,0 +1,18 @@
+import org.scalatest.WordSpec
+
+class SetSpec extends WordSpec {
+
+  "A Set" when {
+    "empty" should {
+      "have size 0" in {
+        assert(Set.empty.size == 0)
+      }
+
+      "produce NoSuchElementException when head is invoked" in {
+        assertThrows[NoSuchElementException] {
+          Set.empty.head
+        }
+      }
+    }
+  }
+}

--- a/spec/sbttest_spec.vim
+++ b/spec/sbttest_spec.vim
@@ -60,11 +60,32 @@ describe "SBT"
     Expect g:test#last_command == 'sbt "testOnly *whatever_suite_smth"'
   end
 
-  it "runs nearest tests"
+  it "runs nearest tests for FunSuite style"
     view +32 FixtureTestSuite.scala
     TestNearest
 
     Expect g:test#last_command == 'sbt "testOnly *FixtureTestSuite -- -z \"Assert '."\\'".'add'."\\'".' works for Double and returns Double\""'
+  end
+
+  it "runs nearest tests for FlatSpec style"
+    view +14 FixtureSpec.scala
+    TestNearest
+
+    Expect g:test#last_command == 'sbt "testOnly *FixtureSpec -- -z \"throw NoSuchElementException if an empty stack is popped\""'
+  end
+
+  it "runs nearest tests for first test in FlatSpec style"
+    view +6 FixtureSpec.scala
+    TestNearest
+
+    Expect g:test#last_command == 'sbt "testOnly *FixtureSpec -- -z \"pop values in last-in-first-out order\""'
+  end
+
+  it "runs nearest tests for first test in WordSpec style"
+    view +7 WordSpec.scala
+    TestNearest
+
+    Expect g:test#last_command == 'sbt "testOnly *WordSpec -- -z \"have size 0\""'
   end
 
   it "runs a suite"

--- a/spec/sbttest_spec.vim
+++ b/spec/sbttest_spec.vim
@@ -18,6 +18,13 @@ describe "SBT"
     Expect g:test#last_command == 'sbt "testOnly *FixtureTest"'
   end
 
+  it "runs when filename matches *Spec.scala"
+    view FixtureSpec.scala
+    TestFile
+
+    Expect g:test#last_command == 'sbt "testOnly *FixtureSpec"'
+  end
+
   it "runs when filename matches *Suite.scala"
     view FixtureSuite.scala
     TestFile


### PR DESCRIPTION
This adds test for a testing style that was added a while ago, the `WordSpec` style and adds support for the commonly used `FlatSpec` style.


- [x ] Add fixtures and spec when implementing or updating a test runner
