### PR TITLE
Improve haskell regext to stop matching on "

### DIFF
--- a/autoload/test/haskell.vim
+++ b/autoload/test/haskell.vim
@@ -1,5 +1,5 @@
 let test#haskell#patterns = {
-  \ 'test':      ['\v\s*describe\s"(.*)"', '\v^\s*it\s"(.*)".*$'],
+  \ 'test':      ['\v\s*describe\s"([^"]*)"', '\v^\s*it\s"([^"]*)".*$'],
   \ 'namespace': [],
 \}
 


### PR DESCRIPTION
If there were more semicolons on the right the `TeastNearest` could have not the correct match eg matching the whole line:
```haskell
  it "inserts into a list" $ insert "A" ["B"] `shouldBe` ["A", "B"]
```
instead of only the `it` block