### PR TITLE
Codeception and Dusk regex

### DIFF
--- a/autoload/test/php/codeception.vim
+++ b/autoload/test/php/codeception.vim
@@ -13,7 +13,7 @@ function! test#php#codeception#build_position(type, position) abort
   if a:type ==# 'nearest'
     let testname = s:nearest_test(a:position)
     let filename = a:position['file']
-    if !empty(testname) | let filename .= ':' . testname | endif
+    if !empty(testname) | let filename .= '::' . testname . '$' | endif
     return [filename]
   elseif a:type ==# 'file'
     return [a:position['file']]

--- a/autoload/test/php/dusk.vim
+++ b/autoload/test/php/dusk.vim
@@ -10,7 +10,7 @@ endfunction
 function! test#php#dusk#build_position(type, position) abort
   if a:type ==# 'nearest'
     let name = s:nearest_test(a:position)
-    if !empty(name) | let name = '--filter '.shellescape(name, 1) | endif
+    if !empty(name) | let name = '--filter '.shellescape('::' . name . '$', 1) | endif
     return [name, a:position['file']]
   elseif a:type ==# 'file'
     return [a:position['file']]

--- a/spec/codeception_spec.vim
+++ b/spec/codeception_spec.vim
@@ -44,7 +44,7 @@ describe "Codeception"
     TestNearest
 
     Expect g:test#last_command ==
-          \ 'codecept run tests/functional/NormalCest.php:tryToTestSomethingElse'
+          \ 'codecept run tests/functional/NormalCest.php::tryToTestSomethingElse$'
   end
 
   it "runs cept nearest tests"
@@ -66,7 +66,7 @@ describe "Codeception"
     TestNearest
 
     Expect g:test#last_command ==
-          \ 'codecept run tests/functional/NormalTest.php:testMe'
+          \ 'codecept run tests/functional/NormalTest.php::testMe$'
   end
 
   it "runs test suites"

--- a/spec/dusk_spec.vim
+++ b/spec/dusk_spec.vim
@@ -27,16 +27,16 @@ describe "Dusk"
     view +10 BrowserTest.php
     TestNearest
 
-    Expect g:test#last_command == "php artisan dusk --colors --filter 'testShouldAddTwoNumbers' BrowserTest.php"
+    Expect g:test#last_command == "php artisan dusk --colors --filter '::testShouldAddTwoNumbers$' BrowserTest.php"
 
     view +15 BrowserTest.php
     TestNearest
 
-    Expect g:test#last_command == "php artisan dusk --colors --filter 'testShouldSubtractTwoNumbers' BrowserTest.php"
+    Expect g:test#last_command == "php artisan dusk --colors --filter '::testShouldSubtractTwoNumbers$' BrowserTest.php"
 
     view +31 BrowserTest.php
     TestNearest
 
-    Expect g:test#last_command == "php artisan dusk --colors --filter 'testShouldAddToExpectedValue' BrowserTest.php"
+    Expect g:test#last_command == "php artisan dusk --colors --filter '::testShouldAddToExpectedValue$' BrowserTest.php"
   end
 end


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`

This is similar to #227 that I submitted a couple years ago, but this time it's for Codeception and Dusk. I recently worked on a project with Codeception and was reminded how annoying it is without this regex :)
