### PR TITLE
Add shtuff as an available strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ let test#strategy = "dispatch"
 | **Terminal.app**                | `terminal`                       | Sends test commands to Terminal (useful in MacVim GUI).                          |
 | **iTerm2.app**                  | `iterm`                          | Sends test commands to iTerm2 >= 2.9 (useful in MacVim GUI).                     |
 | **[Kitty]**                     | `kitty`                          | Sends test commands to Kitty terminal.                                           |
+| **[Shtuff]**                    | `shtuff`                         | Sends test commands to remote terminal via [shtuff].                             |
 
 You can also set up strategies per granularity:
 
@@ -156,6 +157,27 @@ please make sure:
   ```
   $ export KITTY_LISTEN_ON=/tmp/mykitty
   ```
+
+### Shtuff strategy setup
+
+This strategy lets you run commands in a remote terminal without needing tools
+like `tmux` or special terminals such as Kitty.
+
+Before you can run tests using this strategy, you will need to have a terminal
+setup as a receiver, and also you'll need to set `g:shtuff_receiver` in your
+vimrc file.
+
+In your terminal of choice:
+
+```
+$ shtuff as devrunner
+```
+
+And in your vimrc:
+
+```
+let g:shtuff_receiver = 'devrunner'
+```
 
 ### Quickfix Strategies
 
@@ -566,3 +588,5 @@ Copyright © Janko Marohnić. Distributed under the same terms as Vim itself. Se
 [M]: http://github.com/qrush/m
 [projectionist.vim]: https://github.com/tpope/vim-projectionist
 [Kitty]: https://github.com/kovidgoyal/kitty
+[Shtuff]: https://github.com/jfly/shtuff
+[shtuff]: https://github.com/jfly/shtuff

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ let test#strategy = "dispatch"
 | **Terminal.app**                | `terminal`                       | Sends test commands to Terminal (useful in MacVim GUI).                          |
 | **iTerm2.app**                  | `iterm`                          | Sends test commands to iTerm2 >= 2.9 (useful in MacVim GUI).                     |
 | **[Kitty]**                     | `kitty`                          | Sends test commands to Kitty terminal.                                           |
-| **[Shtuff]**                    | `shtuff`                         | Sends test commands to remote terminal via [shtuff].                             |
+| **[Shtuff]**                    | `shtuff`                         | Sends test commands to remote terminal via [shtuff][Shtuff].                     |
 
 You can also set up strategies per granularity:
 
@@ -589,4 +589,3 @@ Copyright © Janko Marohnić. Distributed under the same terms as Vim itself. Se
 [projectionist.vim]: https://github.com/tpope/vim-projectionist
 [Kitty]: https://github.com/kovidgoyal/kitty
 [Shtuff]: https://github.com/jfly/shtuff
-[shtuff]: https://github.com/jfly/shtuff

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -109,6 +109,15 @@ function! test#strategy#kitty(cmd) abort
   call s:execute_script('kitty_runner', cmd)
 endfunction
 
+function! test#strategy#shtuff(cmd) abort
+  if !exists('g:shtuff_receiver')
+    echoerr 'You must define g:shtuff_receiver to use this strategy'
+    return
+  endif
+
+  call system("shtuff into " . shellescape(g:shtuff_receiver) . " " . shellescape("clear;" . a:cmd))
+endfunction
+
 function! s:execute_with_compiler(cmd, script) abort
   try
     let default_makeprg = &l:makeprg

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -371,6 +371,27 @@ You can then use this strategy this way:
   let test#strategy = 'kitty'
 <
 
+Shtuff ~
+
+This strategy lets you run commands in a remote terminal without needing tools
+like tmux or special terminals such as Kitty.
+
+Before you can run tests using this strategy, you will need to have a terminal
+setup as a receiver, and also you'll need to set `g:shtuff_receiver` in your
+vimrc file.
+
+In your terminal of choice:
+
+>
+$ shtuff as devrunner
+<
+
+And in your vimrc:
+
+>
+let g:shtuff_receiver = 'devrunner'
+<
+
 QUICKFIX STRATEGIES                               *test-quickfix-strategies*
 
 If you want your test results to appear in the |quickfix| window, use one of the


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`

[Shtuff] is a tool to allow any terminal to become a remote listening terminal. This is a custom strategy I've had for awhile now, but a few others have started using it so I figured it was time to see if I could get it merged in!

[Shtuff]: https://github.com/jfly/shtuff
