### PR TITLE
support reading package.json from non-root cwd

### DIFF
--- a/autoload/test/javascript.vim
+++ b/autoload/test/javascript.vim
@@ -4,7 +4,8 @@ let test#javascript#patterns = {
 \}
 
 function! test#javascript#has_package(package) abort
-  for line in readfile('package.json')
+  let json_path = findfile('package.json', '.;')
+  for line in readfile(json_path)
     if line =~ '"'.a:package.'"'
       return 1
     endif


### PR DESCRIPTION
This is an extremely minor change to allow for reading package.json in a non root location. I am doing client work on a massive repository, and frequently will `:cd` into a project directory when I am working on it in order to have a sane fzf experience :)