### PR TITLE
Remove --no-coverage flag from jest

### DIFF
--- a/autoload/test/javascript/jest.vim
+++ b/autoload/test/javascript/jest.vim
@@ -13,9 +13,9 @@ function! test#javascript#jest#build_position(type, position) abort
     if !empty(name)
       let name = '-t '.shellescape(name, 1)
     endif
-    return ['--no-coverage', name, '--', a:position['file']]
+    return [name, '--', a:position['file']]
   elseif a:type ==# 'file'
-    return ['--no-coverage', '--', a:position['file']]
+    return ['--', a:position['file']]
   else
     return []
   endif

--- a/spec/jest_spec.vim
+++ b/spec/jest_spec.vim
@@ -16,68 +16,68 @@ describe "Jest"
       view +1 __tests__/normal-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest  -t ''^Math'' -- __tests__/normal-test.js'
+      Expect g:test#last_command == 'jest -t ''^Math'' -- __tests__/normal-test.js'
 
       view +2 __tests__/normal-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest  -t ''^Math Addition'' -- __tests__/normal-test.js'
+      Expect g:test#last_command == 'jest -t ''^Math Addition'' -- __tests__/normal-test.js'
 
       view +3 __tests__/normal-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest  -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.js'
+      Expect g:test#last_command == 'jest -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.js'
     end
 
     it "aliases context to describe"
       view +1 __tests__/context-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest  -t ''^Math'' -- __tests__/context-test.js'
+      Expect g:test#last_command == 'jest -t ''^Math'' -- __tests__/context-test.js'
 
       view +2 __tests__/context-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest  -t ''^Math Addition'' -- __tests__/context-test.js'
+      Expect g:test#last_command == 'jest -t ''^Math Addition'' -- __tests__/context-test.js'
 
       view +3 __tests__/context-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest  -t ''^Math Addition adds two numbers$'' -- __tests__/context-test.js'
+      Expect g:test#last_command == 'jest -t ''^Math Addition adds two numbers$'' -- __tests__/context-test.js'
     end
 
     it "runs CoffeeScript"
       view +1 __tests__/normal-test.coffee
       TestNearest
 
-      Expect g:test#last_command == 'jest  -t ''^Math'' -- __tests__/normal-test.coffee'
+      Expect g:test#last_command == 'jest -t ''^Math'' -- __tests__/normal-test.coffee'
 
       view +2 __tests__/normal-test.coffee
       TestNearest
 
-      Expect g:test#last_command == 'jest  -t ''^Math Addition'' -- __tests__/normal-test.coffee'
+      Expect g:test#last_command == 'jest -t ''^Math Addition'' -- __tests__/normal-test.coffee'
 
       view +3 __tests__/normal-test.coffee
       TestNearest
 
-      Expect g:test#last_command == 'jest  -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.coffee'
+      Expect g:test#last_command == 'jest -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.coffee'
     end
 
     it "runs React"
       view +1 __tests__/normal-test.jsx
       TestNearest
 
-      Expect g:test#last_command == 'jest  -t ''^Math'' -- __tests__/normal-test.jsx'
+      Expect g:test#last_command == 'jest -t ''^Math'' -- __tests__/normal-test.jsx'
 
       view +2 __tests__/normal-test.jsx
       TestNearest
 
-      Expect g:test#last_command == 'jest  -t ''^Math Addition'' -- __tests__/normal-test.jsx'
+      Expect g:test#last_command == 'jest -t ''^Math Addition'' -- __tests__/normal-test.jsx'
 
       view +3 __tests__/normal-test.jsx
       TestNearest
 
-      Expect g:test#last_command == 'jest  -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.jsx'
+      Expect g:test#last_command == 'jest -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.jsx'
     end
   end
 
@@ -86,14 +86,14 @@ describe "Jest"
     normal O
     TestNearest
 
-    Expect g:test#last_command == 'jest  -- __tests__/normal-test.js'
+    Expect g:test#last_command == 'jest -- __tests__/normal-test.js'
   end
 
   it "runs file tests"
     view __tests__/normal-test.js
     TestFile
 
-    Expect g:test#last_command == 'jest  -- __tests__/normal-test.js'
+    Expect g:test#last_command == 'jest -- __tests__/normal-test.js'
   end
 
   it "runs test suites"
@@ -107,7 +107,7 @@ describe "Jest"
     view outside-test.js
     TestFile
 
-    Expect g:test#last_command == 'jest  -- outside-test.js'
+    Expect g:test#last_command == 'jest -- outside-test.js'
   end
 
   context "with a specified executable"
@@ -120,7 +120,7 @@ describe "Jest"
       view __tests__/normal-test.js
       TestFile
 
-      Expect g:test#last_command == 'npm run jest  -- __tests__/normal-test.js'
+      Expect g:test#last_command == 'npm run jest -- __tests__/normal-test.js'
     end
 
     it "runs tests against yarn executable (without --)"
@@ -128,7 +128,7 @@ describe "Jest"
       view __tests__/normal-test.js
       TestFile
 
-      Expect g:test#last_command == 'yarn jest  __tests__/normal-test.js'
+      Expect g:test#last_command == 'yarn jest __tests__/normal-test.js'
     end
 
     it "runs tests against absolute path yarn executable (without --)"
@@ -136,7 +136,7 @@ describe "Jest"
       view __tests__/normal-test.js
       TestFile
 
-      Expect g:test#last_command == '~/.local/bin/yarn jest  __tests__/normal-test.js'
+      Expect g:test#last_command == '~/.local/bin/yarn jest __tests__/normal-test.js'
     end
   end
 

--- a/spec/jest_spec.vim
+++ b/spec/jest_spec.vim
@@ -16,68 +16,68 @@ describe "Jest"
       view +1 __tests__/normal-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage -t ''^Math'' -- __tests__/normal-test.js'
+      Expect g:test#last_command == 'jest  -t ''^Math'' -- __tests__/normal-test.js'
 
       view +2 __tests__/normal-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage -t ''^Math Addition'' -- __tests__/normal-test.js'
+      Expect g:test#last_command == 'jest  -t ''^Math Addition'' -- __tests__/normal-test.js'
 
       view +3 __tests__/normal-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.js'
+      Expect g:test#last_command == 'jest  -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.js'
     end
 
     it "aliases context to describe"
       view +1 __tests__/context-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage -t ''^Math'' -- __tests__/context-test.js'
+      Expect g:test#last_command == 'jest  -t ''^Math'' -- __tests__/context-test.js'
 
       view +2 __tests__/context-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage -t ''^Math Addition'' -- __tests__/context-test.js'
+      Expect g:test#last_command == 'jest  -t ''^Math Addition'' -- __tests__/context-test.js'
 
       view +3 __tests__/context-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage -t ''^Math Addition adds two numbers$'' -- __tests__/context-test.js'
+      Expect g:test#last_command == 'jest  -t ''^Math Addition adds two numbers$'' -- __tests__/context-test.js'
     end
 
     it "runs CoffeeScript"
       view +1 __tests__/normal-test.coffee
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage -t ''^Math'' -- __tests__/normal-test.coffee'
+      Expect g:test#last_command == 'jest  -t ''^Math'' -- __tests__/normal-test.coffee'
 
       view +2 __tests__/normal-test.coffee
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage -t ''^Math Addition'' -- __tests__/normal-test.coffee'
+      Expect g:test#last_command == 'jest  -t ''^Math Addition'' -- __tests__/normal-test.coffee'
 
       view +3 __tests__/normal-test.coffee
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.coffee'
+      Expect g:test#last_command == 'jest  -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.coffee'
     end
 
     it "runs React"
       view +1 __tests__/normal-test.jsx
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage -t ''^Math'' -- __tests__/normal-test.jsx'
+      Expect g:test#last_command == 'jest  -t ''^Math'' -- __tests__/normal-test.jsx'
 
       view +2 __tests__/normal-test.jsx
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage -t ''^Math Addition'' -- __tests__/normal-test.jsx'
+      Expect g:test#last_command == 'jest  -t ''^Math Addition'' -- __tests__/normal-test.jsx'
 
       view +3 __tests__/normal-test.jsx
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.jsx'
+      Expect g:test#last_command == 'jest  -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.jsx'
     end
   end
 
@@ -86,14 +86,14 @@ describe "Jest"
     normal O
     TestNearest
 
-    Expect g:test#last_command == 'jest --no-coverage -- __tests__/normal-test.js'
+    Expect g:test#last_command == 'jest  -- __tests__/normal-test.js'
   end
 
   it "runs file tests"
     view __tests__/normal-test.js
     TestFile
 
-    Expect g:test#last_command == 'jest --no-coverage -- __tests__/normal-test.js'
+    Expect g:test#last_command == 'jest  -- __tests__/normal-test.js'
   end
 
   it "runs test suites"
@@ -107,7 +107,7 @@ describe "Jest"
     view outside-test.js
     TestFile
 
-    Expect g:test#last_command == 'jest --no-coverage -- outside-test.js'
+    Expect g:test#last_command == 'jest  -- outside-test.js'
   end
 
   context "with a specified executable"
@@ -120,7 +120,7 @@ describe "Jest"
       view __tests__/normal-test.js
       TestFile
 
-      Expect g:test#last_command == 'npm run jest --no-coverage -- __tests__/normal-test.js'
+      Expect g:test#last_command == 'npm run jest  -- __tests__/normal-test.js'
     end
 
     it "runs tests against yarn executable (without --)"
@@ -128,7 +128,7 @@ describe "Jest"
       view __tests__/normal-test.js
       TestFile
 
-      Expect g:test#last_command == 'yarn jest --no-coverage __tests__/normal-test.js'
+      Expect g:test#last_command == 'yarn jest  __tests__/normal-test.js'
     end
 
     it "runs tests against absolute path yarn executable (without --)"
@@ -136,7 +136,7 @@ describe "Jest"
       view __tests__/normal-test.js
       TestFile
 
-      Expect g:test#last_command == '~/.local/bin/yarn jest --no-coverage __tests__/normal-test.js'
+      Expect g:test#last_command == '~/.local/bin/yarn jest  __tests__/normal-test.js'
     end
   end
 


### PR DESCRIPTION
A `--no-coverage` flag was being added to every test command for Jest,
but I don't see this option in their configuration and it was causing
issues with one of my repos.

Is there a reason this was added? I'd be interested in trying to add an option that conditionally adds this if it's necessary.

https://jestjs.io/docs/en/cli

Make sure these boxes are checked before submitting your pull request:

_I removed 2 of the checkboxes, because they did not apply to this change. Let me know if I should implement doc changes for this._

- [X] Add fixtures and spec when implementing or updating a test runner
