### PR TITLE
Add Slimux strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ let test#strategy = "dispatch"
 | **[Dispatch]**                  | `dispatch` `dispatch_background` | Runs test commands with `:Dispatch` or `:Dispatch!`.                             |
 | **[Vimux]**                     | `vimux`                          | Runs test commands in a small tmux pane at the bottom of your terminal.          |
 | **[Tslime]**                    | `tslime`                         | Runs test commands in a tmux pane you specify.                                   |
+| **[Slimux]**                    | `slimux`                         | Runs test commands in a tmux pane you specify.                                   |
 | **[Neoterm]**                   | `neoterm`                        | Runs test commands with `:T`, see neoterm docs for display customization.        |
 | **[Neomake]**                   | `neomake`                        | Runs test commands asynchronously with `:NeomakeProject`.                        |
 | **[MakeGreen]**                 | `makegreen`                      | Runs test commands with `:MakeGreen`.                                            |
@@ -577,6 +578,7 @@ Copyright © Janko Marohnić. Distributed under the same terms as Vim itself. Se
 [Dispatch]: https://github.com/tpope/vim-dispatch
 [Vimux]: https://github.com/benmills/vimux
 [Tslime]: https://github.com/jgdavey/tslime.vim
+[Slimux]: https://github.com/esamattis/slimux
 [Vim&nbsp;Tmux&nbsp;Runner]: https://github.com/christoomey/vim-tmux-runner
 [VimShell]: https://github.com/Shougo/vimshell.vim
 [VimProc]: https://github.com/Shougo/vimproc.vim

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -90,6 +90,14 @@ function! test#strategy#tslime(cmd) abort
   call Send_to_Tmux(s:pretty_command(a:cmd)."\n")
 endfunction
 
+function! test#strategy#slimux(cmd) abort
+  if exists('g:test#preserve_screen') && !g:test#preserve_screen
+    call SlimuxSendCommand(s:pretty_command(a:cmd))
+  else
+    call SlimuxSendCommand(s:command(a:cmd))
+  endif
+endfunction
+
 function! test#strategy#vimshell(cmd) abort
   execute 'VimShellExecute '.a:cmd
 endfunction

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -329,6 +329,13 @@ and Tmux.
 >
   let test#strategy = 'tslime'
 <
+Slimux ~
+
+Runs test commands in a Tmux pane you specify. Requires the slimux plugin and
+Tmux.
+>
+  let test#strategy = 'slimux'
+<
 Vim Tmux Runner ~
 
 Runs test commands in a small Tmux pane. Requires the Vim Timux Runner plugin


### PR DESCRIPTION
[Slimux](https://github.com/esamattis/slimux) is yet another plugin to integrate Vim and tmux.

A note about using `command` or `pretty_command`.

When using `pretty_command` with the `preserve_screen` option enabled, the working environment looks like this:

![A redundant echo command is written before every command](https://user-images.githubusercontent.com/348557/69456578-46e07b80-0d6b-11ea-8737-753af7477bc4.png)

So in order to remove the `echo` part in this situation, I've decided to use `command` when the `preserve_screen` option is enabled. Maybe the same can be applied to other tmux strategies, but since I'm not so familiar with them, I haven't changed any of them.

Of course, I can change it to a more suitable behaviour if needed :wink:.

P.S. I'm new to Vimscript so maybe the condition `if exists('g:test#preserve_screen') && !g:test#preserve_screen` could be simplified. Feel free to correct me! :smile:
P.P.S. I haven't seen any tests for any other tmux strategies, so I haven't added any tests either.