### PR TITLE
Add support for python mamba test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ runners are supported:
 | **Lua**        | Busted                                                                                      | `busted`                                                                                                        |
 | **PHP**        | Behat, Codeception, Kahlan, Peridot, PHPUnit, PHPSpec, Dusk                                 | `behat`, `codeception`, `dusk`, `kahlan`, `peridot`, `phpunit`, `phpspec`                                       |
 | **Perl**       | Prove                                                                                       | `prove`                                                                                                         |
-| **Python**     | Django, Nose, Nose2, PyTest, PyUnit                                                         | `djangotest`, `djangonose` `nose`, `nose2`, `pytest`, `pyunit`                                                  |
+| **Python**     | Django, Mamba, Nose, Nose2, PyTest, PyUnit                                                  | `djangotest`, `djangonose`, `mamba`, `nose`, `nose2`, `pytest`, `pyunit`                                                  |
 | **Racket**     | RackUnit                                                                                    | `rackunit`                                                                                                      |
 | **Ruby**       | Cucumber, [M], [Minitest][minitest], Rails, RSpec                                           | `cucumber`, `m`, `minitest`, `rails`, `rspec`                                                                   |
 | **Rust**       | Cargo                                                                                       | `cargotest`                                                                                                     |
@@ -373,7 +373,7 @@ the first available will be chosen, but you can force a specific one:
 
 ``` vim
 let test#python#runner = 'pytest'
-" Runners available are 'pytest', 'nose', 'nose2', 'djangotest', 'djangonose' and Python's built-in 'unittest'
+" Runners available are 'pytest', 'nose', 'nose2', 'djangotest', 'djangonose', 'mamba', and Python's built-in 'unittest'
 ```
 
 The pytest runner optionally supports [pipenv](https://github.com/pypa/pipenv).

--- a/autoload/test/python/mamba.vim
+++ b/autoload/test/python/mamba.vim
@@ -1,0 +1,55 @@
+if !exists('g:test#python#mamba#file_pattern')
+  let g:test#python#mamba#file_pattern = '_spec\.py$'
+endif
+
+function! test#python#mamba#test_file(file)
+  if fnamemodify(a:file, ':t') =~# g:test#python#mamba#file_pattern
+    if exists('g:test#python#runner')
+      return g:test#python#runner ==# 'mamba'
+    else
+      return executable("mamba")
+    endif
+  endif
+endfunction
+
+function! test#python#mamba#build_position(type, position) abort
+  if a:type ==# 'nearest'
+    let name = s:nearest_test(a:position)
+    if !empty(name)
+      return [a:position['file'].':'.name]
+    else
+      return [a:position['file']]
+    endif
+  elseif a:type ==# 'file'
+    return [a:position['file']]
+  else
+    return []
+  endif
+endfunction
+
+function! test#python#mamba#build_args(args) abort
+  let args = a:args
+
+  if test#base#no_colors()
+    let args = ['--color=no'] + args
+  endif
+
+  return args
+endfunction
+
+function! test#python#mamba#executable() abort
+  let pipenv_prefix = ""
+
+  if filereadable("Pipfile")
+    let pipenv_prefix = "pipenv run "
+  elseif filereadable("poetry.lock")
+    let pipenv_prefix = "poetry run "
+  endif
+
+  return pipenv_prefix . "mamba"
+endfunction
+
+function! s:nearest_test(position) abort
+  let name = test#base#nearest_test(a:position, g:test#python#patterns)
+  return get(name['test'], 0, '')
+endfunction

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -136,6 +136,9 @@ In all commands [args] are forwarded to the underlying test runner.
                                                 *test-:PyUnit*
 :PyUnit [args]               Uses the `unittest` `test` command.
 
+                                                *test-:Mamba*
+:Mamba [args]                Uses the `mamba` `test` command.
+
                                                 *test-:ElmTest*
 :ElmTest [args]              Uses the `elm-test` command.
 

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -8,7 +8,7 @@ let g:test#plugin_path = expand('<sfile>:p:h:h')
 let g:test#default_runners = {
   \ 'Ruby':       ['Rails', 'M', 'Minitest', 'RSpec', 'Cucumber'],
   \ 'JavaScript': ['Ava', 'CucumberJS', 'Intern', 'TAP', 'Karma', 'Lab', 'Mocha', 'Jasmine', 'Jest', 'ReactScripts', 'WebdriverIO', 'Cypress'],
-  \ 'Python':     ['DjangoTest', 'PyTest', 'PyUnit', 'Nose', 'Nose2'],
+  \ 'Python':     ['DjangoTest', 'PyTest', 'PyUnit', 'Nose', 'Nose2', 'Mamba'],
   \ 'Elixir':     ['ExUnit', 'ESpec'],
   \ 'Elm':        ['ElmTest'],
   \ 'Erlang':     ['CommonTest', 'EUnit'],

--- a/spec/fixtures/mamba/normal_spec.py
+++ b/spec/fixtures/mamba/normal_spec.py
@@ -1,0 +1,6 @@
+from mamba import description, context, it
+from expects import expect, equal
+
+with description('Addition') as self:
+  with it('adds two numbers'):
+    expect(1 + 1).to(equal(2))

--- a/spec/mamba_spec.vim
+++ b/spec/mamba_spec.vim
@@ -1,0 +1,34 @@
+source spec/support/helpers.vim
+
+describe "Mamba"
+  before
+    let g:test#python#runner = 'mamba'
+    cd spec/fixtures/mamba
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "runs nearest tests"
+    view +1 normal_spec.py
+    TestNearest
+
+    Expect g:test#last_command == 'mamba normal_spec.py'
+  end
+
+  it "runs file tests"
+    view normal_spec.py
+    TestFile
+
+    Expect g:test#last_command == 'mamba normal_spec.py'
+  end
+
+  it "runs test suites"
+    view normal_spec.py
+    TestSuite
+
+    Expect g:test#last_command == 'mamba'
+  end
+end


### PR DESCRIPTION
This adds support for the python "Mamba" BDD test runner.

https://nestorsalceda.com/mamba/

Note: The mamba test runner doesn't support running a single test by line number or pattern, it depends on explicit tags or 'fit' style focus. So, this works similar to the busted test runner, where it will still run the whole file for TestNearest.

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
