### PR TITLE
Add support for TestifyNearest

### DIFF
--- a/autoload/test/viml/testify.vim
+++ b/autoload/test/viml/testify.vim
@@ -7,7 +7,9 @@ function! test#viml#testify#test_file(file) abort
 endfunction
 
 function! test#viml#testify#build_position(type, position) abort
-  if a:type ==# 'nearest' || a:type ==# 'file'
+  if a:type ==# 'nearest'
+    return [':TestifyNearest']
+  elseif a:type ==# 'file'
     return [':TestifyFile']
   endif
   return [':TestifySuite']

--- a/spec/testify_spec.vim
+++ b/spec/testify_spec.vim
@@ -13,11 +13,11 @@ describe "Testify"
     cd -
   end
 
-  it "runs file tests instead of nearest tests"
+  it "runs nearest tests"
     view +3 test/normal.vim
     TestNearest
 
-    Expect g:test#last_command == ':TestifyFile'
+    Expect g:test#last_command == ':TestifyNearest'
   end
 
   it "runs file tests"


### PR DESCRIPTION
Added support for running nearest tests in testify so ported that to vim-test.

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
