### PR TITLE
Support more class modifier keywords

### DIFF
--- a/autoload/test/swift.vim
+++ b/autoload/test/swift.vim
@@ -1,5 +1,5 @@
 let g:test#swift#patterns = {
   \ 'test':      ['\v^\s*func (test.*)\(\)'],
-  \ 'namespace': ['\v^%(final )?class ([-_a-zA-Z0-9]+): XCTestCase'],
+  \ 'namespace': ['\v^%(%(public )?%(final )?|%(final )?%(public )?)class ([-_a-zA-Z0-9]+): XCTestCase'],
   \ 'module':    ['\v^Tests\/([-_ a-zA-Z0-9]+)%(\/|\.swift)']
 \}

--- a/spec/fixtures/swiftpm/Tests/VimTestTests/VimTestFinalPublicTests.swift
+++ b/spec/fixtures/swiftpm/Tests/VimTestTests/VimTestFinalPublicTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import VimTest
+
+final public class VimTestFinalPublicTests: XCTestCase {
+  func testExample() {
+    XCTAssertEqual(VimTest().text, "Hello, World!")
+  }
+
+  static var allTests = [
+    ("testExample", testExample),
+  ]
+}

--- a/spec/fixtures/swiftpm/Tests/VimTestTests/VimTestPublicFinalTests.swift
+++ b/spec/fixtures/swiftpm/Tests/VimTestTests/VimTestPublicFinalTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import VimTest
+
+public final class VimTestPublicFinalTests: XCTestCase {
+  func testExample() {
+    XCTAssertEqual(VimTest().text, "Hello, World!")
+  }
+
+  static var allTests = [
+    ("testExample", testExample),
+  ]
+}

--- a/spec/fixtures/swiftpm/Tests/VimTestTests/VimTestPublicTests.swift
+++ b/spec/fixtures/swiftpm/Tests/VimTestTests/VimTestPublicTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import VimTest
+
+public class VimTestPublicTests: XCTestCase {
+  func testExample() {
+    XCTAssertEqual(VimTest().text, "Hello, World!")
+  }
+
+  func testOther() {
+    XCTAssertEqual(true, true)
+  }
+
+  static var allTests = [
+    ("testExample", testExample),
+    ("testOther", testOther)
+  ]
+}

--- a/spec/swiftpm_spec.vim
+++ b/spec/swiftpm_spec.vim
@@ -42,6 +42,27 @@ describe "SwiftPM"
     Expect g:test#last_command == 'swift test --filter VimTestTests.VimTestFinalTests'
   end
 
+  it "recognizes public test cases"
+    view Tests/VimTestTests/VimTestPublicTests.swift
+    TestFile
+
+    Expect g:test#last_command == 'swift test --filter VimTestTests.VimTestPublicTests'
+  end
+
+  it "recognizes public final test cases"
+    view Tests/VimTestTests/VimTestPublicFinalTests.swift
+    TestFile
+
+    Expect g:test#last_command == 'swift test --filter VimTestTests.VimTestPublicFinalTests'
+  end
+
+  it "recognizes final public test cases"
+    view Tests/VimTestTests/VimTestFinalPublicTests.swift
+    TestFile
+
+    Expect g:test#last_command == 'swift test --filter VimTestTests.VimTestFinalPublicTests'
+  end
+
   it "recognizes test cases in the root of the test directory"
     view Tests/VimTestRootTests.swift
     TestFile


### PR DESCRIPTION
Adds support for test classes that are public, public final or final
public. While rare it is allowed for test classes to have these
modifiers.

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
~- [ ] Update the README accordingly~ n.a.
~- [ ] Update the Vim documentation in `doc/test.txt`~ n.a.

Fixes https://github.com/janko/vim-test/issues/419
