### PR TITLE
Fixes issues with running any kind of test with MacVim

### DIFF
--- a/autoload/test.vim
+++ b/autoload/test.vim
@@ -81,7 +81,7 @@ function! test#execute(runner, args, ...) abort
   call filter(args, '!empty(v:val)')
 
   let executable = test#base#executable(a:runner)
-  let args = test#base#build_args(a:runner, args)
+  let args = test#base#build_args(a:runner, args, strategy)
   let cmd = [executable] + args
   call filter(cmd, '!empty(v:val)')
 

--- a/autoload/test/base.vim
+++ b/autoload/test/base.vim
@@ -44,7 +44,7 @@ endfunction
 
 function! test#base#no_colors() abort
   let strategy = get(g:, 'test#strategy', 'basic')
-  return has('gui_running') && strategy ==# 'basic'
+  return has('gui_running') && strategy['file'] ==# 'basic'
 endfunction
 
 " Takes a position and a dictionary of patterns, and returns list of strings

--- a/autoload/test/base.vim
+++ b/autoload/test/base.vim
@@ -30,8 +30,8 @@ function! test#base#executable(runner) abort
   endif
 endfunction
 
-function! test#base#build_args(runner, args) abort
-  return test#{a:runner}#build_args(a:args)
+function! test#base#build_args(runner, args, strategy) abort
+  return test#{a:runner}#build_args(a:args, a:strategy)
 endfunction
 
 function! test#base#file_exists(file) abort
@@ -42,9 +42,8 @@ function! test#base#escape_regex(string) abort
   return escape(a:string, '?+*\^$.|{}[]()')
 endfunction
 
-function! test#base#no_colors() abort
-  let strategy = get(g:, 'test#strategy', 'basic')
-  return has('gui_running') && strategy['file'] ==# 'basic'
+function! test#base#no_colors(strategy) abort
+  return has('gui_running') && a:strategy ==# 'basic'
 endfunction
 
 " Takes a position and a dictionary of patterns, and returns list of strings

--- a/autoload/test/clojure/fireplacetest.vim
+++ b/autoload/test/clojure/fireplacetest.vim
@@ -22,7 +22,7 @@ function! test#clojure#fireplacetest#build_position(type, position) abort
   endif
 endfunction
 
-function! test#clojure#fireplacetest#build_args(args) abort
+function! test#clojure#fireplacetest#build_args(args, strategy) abort
   if get(a:args, 0, '') =~# 'RunTests'
     return a:args
   else

--- a/autoload/test/crystal/crystalspec.vim
+++ b/autoload/test/crystal/crystalspec.vim
@@ -16,7 +16,7 @@ function! test#crystal#crystalspec#build_position(type, position) abort
   endif
 endfunction
 
-function! test#crystal#crystalspec#build_args(args) abort
+function! test#crystal#crystalspec#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/csharp/dotnettest.vim
+++ b/autoload/test/csharp/dotnettest.vim
@@ -30,7 +30,7 @@ function! test#csharp#dotnettest#build_position(type, position) abort
   endif
 endfunction
 
-function! test#csharp#dotnettest#build_args(args) abort
+function! test#csharp#dotnettest#build_args(args, strategy) abort
   let args = a:args
   return [join(args, ' ')]
 endfunction

--- a/autoload/test/csharp/xunit.vim
+++ b/autoload/test/csharp/xunit.vim
@@ -43,7 +43,7 @@ function! test#csharp#xunit#build_position(type, position) abort
   return []
 endfunction
 
-function! test#csharp#xunit#build_args(args) abort
+function! test#csharp#xunit#build_args(args, strategy) abort
   let l:args = a:args
   call insert(l:args, '-nologo')
   return [join(l:args, ' ')]

--- a/autoload/test/elixir/espec.vim
+++ b/autoload/test/elixir/espec.vim
@@ -16,7 +16,7 @@ function! test#elixir#espec#build_position(type, position) abort
   endif
 endfunction
 
-function! test#elixir#espec#build_args(args) abort
+function! test#elixir#espec#build_args(args, strategy) abort
  return a:args
 endfunction
 

--- a/autoload/test/elixir/exunit.vim
+++ b/autoload/test/elixir/exunit.vim
@@ -24,10 +24,10 @@ function! test#elixir#exunit#build_position(type, position) abort
   end
 endfunction
 
-function! test#elixir#exunit#build_args(args) abort
+function! test#elixir#exunit#build_args(args, strategy) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if test#base#no_colors(a:strategy)
     let args = ['--no-color'] + args
   endif
 

--- a/autoload/test/elm/elmtest.vim
+++ b/autoload/test/elm/elmtest.vim
@@ -21,7 +21,7 @@ function! test#elm#elmtest#build_position(type, position) abort
   endif
 endfunction
 
-function! test#elm#elmtest#build_args(args) abort
+function! test#elm#elmtest#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/erlang/commontest.vim
+++ b/autoload/test/erlang/commontest.vim
@@ -21,7 +21,7 @@ function! test#erlang#commontest#build_position(type, position) abort
     endif
 endfunction
 
-function! test#erlang#commontest#build_args(args) abort
+function! test#erlang#commontest#build_args(args, strategy) abort
   return  ['ct'] + a:args
 endfunction
 

--- a/autoload/test/erlang/eunit.vim
+++ b/autoload/test/erlang/eunit.vim
@@ -17,7 +17,7 @@ function! test#erlang#eunit#build_position(type, position) abort
   endif
 endfunction
 
-function! test#erlang#eunit#build_args(args) abort
+function! test#erlang#eunit#build_args(args, strategy) abort
   return  ['eunit'] + a:args
 endfunction
 

--- a/autoload/test/go/delve.vim
+++ b/autoload/test/go/delve.vim
@@ -29,7 +29,7 @@ function! test#go#delve#build_options(args, options) abort
   return args + a:options
 endfunction
 
-function! test#go#delve#build_args(args) abort
+function! test#go#delve#build_args(args, strategy) abort
   let args = a:args
 
   " Optionally, if the vim-delve plugin is installed this will also include

--- a/autoload/test/go/ginkgo.vim
+++ b/autoload/test/go/ginkgo.vim
@@ -26,10 +26,10 @@ function! test#go#ginkgo#build_position(type, position) abort
   endif
 endfunction
 
-function! test#go#ginkgo#build_args(args) abort
+function! test#go#ginkgo#build_args(args, strategy) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if test#base#no_colors(a:strategy)
     let args = ['--nocolor'] + args
   endif
 

--- a/autoload/test/go/gotest.vim
+++ b/autoload/test/go/gotest.vim
@@ -21,7 +21,7 @@ function! test#go#gotest#build_position(type, position) abort
   endif
 endfunction
 
-function! test#go#gotest#build_args(args) abort
+function! test#go#gotest#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/go/richgo.vim
+++ b/autoload/test/go/richgo.vim
@@ -21,7 +21,7 @@ function! test#go#richgo#build_position(type, position) abort
   endif
 endfunction
 
-function! test#go#richgo#build_args(args) abort
+function! test#go#richgo#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/haskell/stacktest.vim
+++ b/autoload/test/haskell/stacktest.vim
@@ -27,7 +27,7 @@ function! test#haskell#stacktest#build_position(type, position) abort
   endif
 endfunction
 
-function! test#haskell#stacktest#build_args(args) abort
+function! test#haskell#stacktest#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/java/gradletest.vim
+++ b/autoload/test/java/gradletest.vim
@@ -25,7 +25,7 @@ function! test#java#gradletest#build_position(type, position) abort
   endif
 endfunction
 
-function! test#java#gradletest#build_args(args) abort
+function! test#java#gradletest#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/java/maventest.vim
+++ b/autoload/test/java/maventest.vim
@@ -34,7 +34,7 @@ function! test#java#maventest#build_position(type, position) abort
 
 endfunction
 
-function! test#java#maventest#build_args(args) abort
+function! test#java#maventest#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/javascript/ava.vim
+++ b/autoload/test/javascript/ava.vim
@@ -21,10 +21,10 @@ function! test#javascript#ava#build_position(type, position) abort
   endif
 endfunction
 
-function! test#javascript#ava#build_args(args) abort
+function! test#javascript#ava#build_args(args, strategy) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if test#base#no_colors(a:strategy)
     let args = ['--no-color'] + args
   endif
 

--- a/autoload/test/javascript/cucumberjs.vim
+++ b/autoload/test/javascript/cucumberjs.vim
@@ -23,7 +23,7 @@ function! test#javascript#cucumberjs#build_position(type, position) abort
   endif
 endfunction
 
-function! test#javascript#cucumberjs#build_args(args) abort
+function! test#javascript#cucumberjs#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/javascript/cypress.vim
+++ b/autoload/test/javascript/cypress.vim
@@ -16,7 +16,7 @@ function! test#javascript#cypress#build_position(type, position) abort
 endfunction
 
 let s:yarn_command = '\<yarn\>'
-function! test#javascript#cypress#build_args(args) abort
+function! test#javascript#cypress#build_args(args, strategy) abort
   if exists('g:test#javascript#cypress#executable')
     \ && g:test#javascript#cypress#executable =~# s:yarn_command
     return filter(a:args, 'v:val != "--"')

--- a/autoload/test/javascript/intern.vim
+++ b/autoload/test/javascript/intern.vim
@@ -38,7 +38,7 @@ function! test#javascript#intern#build_position(type, position) abort
   endif
 endfunction
 
-function! test#javascript#intern#build_args(args) abort
+function! test#javascript#intern#build_args(args, strategy) abort
   let config = 'config=' . g:test#javascript#intern#config_module
   return [config] + a:args
 endfunction

--- a/autoload/test/javascript/jasmine.vim
+++ b/autoload/test/javascript/jasmine.vim
@@ -21,10 +21,10 @@ function! test#javascript#jasmine#build_position(type, position) abort
   endif
 endfunction
 
-function! test#javascript#jasmine#build_args(args) abort
+function! test#javascript#jasmine#build_args(args, strategy) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if test#base#no_colors(a:strategy)
     let args = ['--no-color'] + args
   endif
 

--- a/autoload/test/javascript/jest.vim
+++ b/autoload/test/javascript/jest.vim
@@ -22,7 +22,7 @@ function! test#javascript#jest#build_position(type, position) abort
 endfunction
 
 let s:yarn_command = '\<yarn\>'
-function! test#javascript#jest#build_args(args) abort
+function! test#javascript#jest#build_args(args, strategy) abort
   if exists('g:test#javascript#jest#executable')
     \ && g:test#javascript#jest#executable =~# s:yarn_command
     return filter(a:args, 'v:val != "--"')

--- a/autoload/test/javascript/karma.vim
+++ b/autoload/test/javascript/karma.vim
@@ -29,14 +29,14 @@ function! test#javascript#karma#build_position(type, position) abort
   endif
 endfunction
 
-function! test#javascript#karma#build_args(args) abort
+function! test#javascript#karma#build_args(args, strategy) abort
   let args = a:args
 
   " reduce clutter in the output by only reporting tests and only run once so
   " we take less time & therefore annoy the user less
   call extend(args, ['--single-run', '--no-auto-watch', '--log-level=disable'])
 
-  if test#base#no_colors()
+  if test#base#no_colors(a:strategy)
     let args = ['--no-color'] + args
   endif
 

--- a/autoload/test/javascript/lab.vim
+++ b/autoload/test/javascript/lab.vim
@@ -28,7 +28,7 @@ function! test#javascript#lab#build_position(type, position) abort
   endif
 endfunction
 
-function! test#javascript#lab#build_args(args) abort
+function! test#javascript#lab#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/javascript/mocha.vim
+++ b/autoload/test/javascript/mocha.vim
@@ -22,10 +22,10 @@ function! test#javascript#mocha#build_position(type, position) abort
   endif
 endfunction
 
-function! test#javascript#mocha#build_args(args) abort
+function! test#javascript#mocha#build_args(args, strategy) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if test#base#no_colors(a:strategy)
     let args = ['--no-colors'] + args
     let args = args + ['|', 'sed -e "s///g"']
   endif

--- a/autoload/test/javascript/reactscripts.vim
+++ b/autoload/test/javascript/reactscripts.vim
@@ -22,7 +22,7 @@ function! test#javascript#reactscripts#build_position(type, position) abort
 endfunction
 
 let s:yarn_command = '\<yarn\>'
-function! test#javascript#reactscripts#build_args(args) abort
+function! test#javascript#reactscripts#build_args(args, strategy) abort
   if exists('g:test#javascript#reactscripts#executable')
     \ && g:test#javascript#reactscripts#executable =~# s:yarn_command
     return filter(a:args, 'v:val != "--"')

--- a/autoload/test/javascript/tap.vim
+++ b/autoload/test/javascript/tap.vim
@@ -23,7 +23,7 @@ function! test#javascript#tap#build_position(type, position) abort
   endif
 endfunction
 
-function! test#javascript#tap#build_args(args) abort
+function! test#javascript#tap#build_args(args, strategy) abort
   let args = a:args
   for executable in g:test#javascript#tap#reporters
     if filereadable('node_modules/.bin/' . executable)

--- a/autoload/test/javascript/webdriverio.vim
+++ b/autoload/test/javascript/webdriverio.vim
@@ -16,7 +16,7 @@ function! test#javascript#webdriverio#build_position(type, position) abort
   endif
 endfunction
 
-function! test#javascript#webdriverio#build_args(args) abort
+function! test#javascript#webdriverio#build_args(args, strategy) abort
   return ['wdio.conf.js'] + a:args
 endfunction
 

--- a/autoload/test/lua/busted.vim
+++ b/autoload/test/lua/busted.vim
@@ -14,7 +14,7 @@ function! test#lua#busted#build_position(type, position) abort
   endif
 endfunction
 
-function! test#lua#busted#build_args(args) abort
+function! test#lua#busted#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/perl/prove.vim
+++ b/autoload/test/perl/prove.vim
@@ -14,7 +14,7 @@ function! test#perl#prove#build_position(type, position) abort
   endif
 endfunction
 
-function! test#perl#prove#build_args(args) abort
+function! test#perl#prove#build_args(args, strategy) abort
   let args = []
   let test_args = []
 
@@ -32,7 +32,7 @@ function! test#perl#prove#build_args(args) abort
     let args = ['--recurse'] + args
   endif
 
-  if test#base#no_colors()
+  if test#base#no_colors(a:strategy)
     let args = ['--nocolor'] + args
   endif
 

--- a/autoload/test/php/behat.vim
+++ b/autoload/test/php/behat.vim
@@ -20,10 +20,10 @@ function! test#php#behat#build_position(type, position) abort
   endif
 endfunction
 
-function! test#php#behat#build_args(args) abort
+function! test#php#behat#build_args(args, strategy) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if test#base#no_colors(a:strategy)
     let args = ['--no-ansi'] + args
   endif
 

--- a/autoload/test/php/codeception.vim
+++ b/autoload/test/php/codeception.vim
@@ -22,10 +22,10 @@ function! test#php#codeception#build_position(type, position) abort
   endif
 endfunction
 
-function! test#php#codeception#build_args(args) abort
+function! test#php#codeception#build_args(args, strategy) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if test#base#no_colors(a:strategy)
     let args = ['--no-ansi'] + args
   endif
 

--- a/autoload/test/php/dusk.vim
+++ b/autoload/test/php/dusk.vim
@@ -19,10 +19,10 @@ function! test#php#dusk#build_position(type, position) abort
   endif
 endfunction
 
-function! test#php#dusk#build_args(args) abort
+function! test#php#dusk#build_args(args, strategy) abort
   let args = a:args
 
-  if !test#base#no_colors()
+  if !test#base#no_colors(a:strategy)
     let args = ['--colors'] + args
   endif
 

--- a/autoload/test/php/kahlan.vim
+++ b/autoload/test/php/kahlan.vim
@@ -14,10 +14,10 @@ function! test#php#kahlan#build_position(type, position) abort
   return []
 endfunction
 
-function! test#php#kahlan#build_args(args) abort
+function! test#php#kahlan#build_args(args, strategy) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if test#base#no_colors(a:strategy)
     let args = ['--no-colors=true'] + args
   endif
 

--- a/autoload/test/php/peridot.vim
+++ b/autoload/test/php/peridot.vim
@@ -18,10 +18,10 @@ function! test#php#peridot#build_position(type, position) abort
   endif
 endfunction
 
-function! test#php#peridot#build_args(args) abort
+function! test#php#peridot#build_args(args, strategy) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if test#base#no_colors(a:strategy)
     let args = ['--no-colors'] + args
   endif
 

--- a/autoload/test/php/phpspec.vim
+++ b/autoload/test/php/phpspec.vim
@@ -17,10 +17,10 @@ function! test#php#phpspec#build_position(type, position) abort
   endif
 endfunction
 
-function! test#php#phpspec#build_args(args) abort
+function! test#php#phpspec#build_args(args, strategy) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if test#base#no_colors(a:strategy)
     let args = ['--no-ansi'] + args
   endif
 

--- a/autoload/test/php/phpunit.vim
+++ b/autoload/test/php/phpunit.vim
@@ -33,10 +33,10 @@ function! test#php#phpunit#build_position(type, position) abort
   endif
 endfunction
 
-function! test#php#phpunit#build_args(args) abort
+function! test#php#phpunit#build_args(args, strategy) abort
   let args = a:args
 
-  if !test#base#no_colors()
+  if !test#base#no_colors(a:strategy)
     let args = ['--colors'] + args
   endif
 

--- a/autoload/test/python/djangotest.vim
+++ b/autoload/test/python/djangotest.vim
@@ -28,7 +28,7 @@ function! test#python#djangotest#build_position(type, position) abort
   endif
 endfunction
 
-function! test#python#djangotest#build_args(args) abort
+function! test#python#djangotest#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/python/mamba.vim
+++ b/autoload/test/python/mamba.vim
@@ -27,10 +27,10 @@ function! test#python#mamba#build_position(type, position) abort
   endif
 endfunction
 
-function! test#python#mamba#build_args(args) abort
+function! test#python#mamba#build_args(args, strategy) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if test#base#no_colors(a:strategy)
     let args = ['--color=no'] + args
   endif
 

--- a/autoload/test/python/nose.vim
+++ b/autoload/test/python/nose.vim
@@ -27,7 +27,7 @@ function! test#python#nose#build_position(type, position) abort
   endif
 endfunction
 
-function! test#python#nose#build_args(args) abort
+function! test#python#nose#build_args(args, strategy) abort
   return ['--doctest-tests'] + a:args
 endfunction
 

--- a/autoload/test/python/nose2.vim
+++ b/autoload/test/python/nose2.vim
@@ -27,7 +27,7 @@ function! test#python#nose2#build_position(type, position) abort
   endif
 endfunction
 
-function! test#python#nose2#build_args(args) abort
+function! test#python#nose2#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/python/pytest.vim
+++ b/autoload/test/python/pytest.vim
@@ -27,10 +27,10 @@ function! test#python#pytest#build_position(type, position) abort
   endif
 endfunction
 
-function! test#python#pytest#build_args(args) abort
+function! test#python#pytest#build_args(args, strategy) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if test#base#no_colors(a:strategy)
     let args = ['--color=no'] + args
   endif
 

--- a/autoload/test/python/pyunit.vim
+++ b/autoload/test/python/pyunit.vim
@@ -28,7 +28,7 @@ function! test#python#pyunit#build_position(type, position) abort
   endif
 endfunction
 
-function! test#python#pyunit#build_args(args) abort
+function! test#python#pyunit#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/racket/rackunit.vim
+++ b/autoload/test/racket/rackunit.vim
@@ -10,7 +10,7 @@ function! test#racket#rackunit#build_position(type, position) abort
   return [a:position['file']]
 endfunction
 
-function! test#racket#rackunit#build_args(args) abort
+function! test#racket#rackunit#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/ruby/cucumber.vim
+++ b/autoload/test/ruby/cucumber.vim
@@ -18,10 +18,10 @@ function! test#ruby#cucumber#build_position(type, position) abort
   endif
 endfunction
 
-function! test#ruby#cucumber#build_args(args) abort
+function! test#ruby#cucumber#build_args(args, strategy) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if test#base#no_colors(a:strategy)
     let args = ['--no-color'] + args
   endif
 

--- a/autoload/test/ruby/m.vim
+++ b/autoload/test/ruby/m.vim
@@ -16,7 +16,7 @@ function! test#ruby#m#build_position(type, position) abort
   endif
 endfunction
 
-function! test#ruby#m#build_args(args) abort
+function! test#ruby#m#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/ruby/minitest.vim
+++ b/autoload/test/ruby/minitest.vim
@@ -21,7 +21,7 @@ function! test#ruby#minitest#build_position(type, position) abort
   endif
 endfunction
 
-function! test#ruby#minitest#build_args(args) abort
+function! test#ruby#minitest#build_args(args, strategy) abort
   for idx in range(0, len(a:args) - 1)
     if test#base#file_exists(a:args[idx])
       let path = remove(a:args, idx) | break

--- a/autoload/test/ruby/rails.vim
+++ b/autoload/test/ruby/rails.vim
@@ -20,7 +20,7 @@ function! test#ruby#rails#build_position(type, position) abort
   endif
 endfunction
 
-function! test#ruby#rails#build_args(args) abort
+function! test#ruby#rails#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/ruby/rspec.vim
+++ b/autoload/test/ruby/rspec.vim
@@ -16,10 +16,10 @@ function! test#ruby#rspec#build_position(type, position) abort
   endif
 endfunction
 
-function! test#ruby#rspec#build_args(args) abort
+function! test#ruby#rspec#build_args(args, strategy) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if test#base#no_colors(a:strategy)
     let args = ['--no-color'] + args
   endif
 

--- a/autoload/test/rust/cargotest.vim
+++ b/autoload/test/rust/cargotest.vim
@@ -42,7 +42,7 @@ function! test#rust#cargotest#build_position(type, position) abort
   return []
 endfunction
 
-function! test#rust#cargotest#build_args(args) abort
+function! test#rust#cargotest#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/scala/blooptest.vim
+++ b/autoload/test/scala/blooptest.vim
@@ -28,7 +28,7 @@ function! test#scala#blooptest#build_position(type, position) abort
   endif
 endfunction
 
-function! test#scala#blooptest#build_args(args) abort
+function! test#scala#blooptest#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/scala/sbttest.vim
+++ b/autoload/test/scala/sbttest.vim
@@ -25,7 +25,7 @@ function! test#scala#sbttest#build_position(type, position) abort
   endif
 endfunction
 
-function! test#scala#sbttest#build_args(args) abort
+function! test#scala#sbttest#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/shell/bats.vim
+++ b/autoload/test/shell/bats.vim
@@ -14,7 +14,7 @@ function! test#shell#bats#build_position(type, position) abort
   endif
 endfunction
 
-function! test#shell#bats#build_args(args) abort
+function! test#shell#bats#build_args(args, strategy) abort
   if empty(filter(copy(a:args), 'test#base#file_exists(v:val)'))
     call add(a:args, 'test/')
   endif

--- a/autoload/test/swift/swiftpm.vim
+++ b/autoload/test/swift/swiftpm.vim
@@ -21,7 +21,7 @@ function! test#swift#swiftpm#build_position(type, position) abort
   endif
 endfunction
 
-function! test#swift#swiftpm#build_args(args) abort
+function! test#swift#swiftpm#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/viml/testify.vim
+++ b/autoload/test/viml/testify.vim
@@ -15,7 +15,7 @@ function! test#viml#testify#build_position(type, position) abort
   return [':TestifySuite']
 endfunction
 
-function! test#viml#testify#build_args(args) abort
+function! test#viml#testify#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/viml/themis.vim
+++ b/autoload/test/viml/themis.vim
@@ -15,7 +15,7 @@ function! test#viml#themis#build_position(type, position) abort
   endif
 endfunction
 
-function! test#viml#themis#build_args(args) abort
+function! test#viml#themis#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/viml/vader.vim
+++ b/autoload/test/viml/vader.vim
@@ -21,7 +21,7 @@ function! test#viml#vader#build_position(type, position) abort
   endif
 endfunction
 
-function! test#viml#vader#build_args(args) abort
+function! test#viml#vader#build_args(args, strategy) abort
   return a:args
 endfunction
 

--- a/autoload/test/viml/vspec.vim
+++ b/autoload/test/viml/vspec.vim
@@ -14,7 +14,7 @@ function! test#viml#vspec#build_position(type, position) abort
   endif
 endfunction
 
-function! test#viml#vspec#build_args(args) abort
+function! test#viml#vspec#build_args(args, strategy) abort
   if empty(filter(copy(a:args), 'test#base#file_exists(v:val)'))
     let test_dir = get(filter(['t/', 'test/', 'spec/'], 'isdirectory(v:val)'), 0)
     call add(a:args, test_dir)


### PR DESCRIPTION
### What?

vim-test checks to see whether colours should be enabled in test output using the 'test#base#no_colors' function.

This function short-circuits when the current version of vim doesn't have the gui_running feature enabled (I imagine this is the majority of cases for users of vim (?)) 

```vim
function! test#base#no_colors() abort
  let strategy = get(g:, 'test#strategy', 'basic')
  return has('gui_running') && strategy ==# 'basic'
endfunction
```

I'm currently using [MacVim](https://github.com/macvim-dev/macvim) for a trial and am hitting the second check (i.e. `strategy ==# 'basic'`) since `has('gui_running')` is true.

However the strategy returned by the following call:
```vim
 let strategy = get(g:, 'test#strategy', 'basic')
```
is not a string and is in fact a dictionary object containing all of the strategies defined for the available run types (i.e. file, nearest and suite):
```vim
{'file':'iterm', 'nearest': 'iterm', 'suite': 'iterm'}
```

This PR fixes the failure arising from comparing a dictionary to a string:

![image](https://user-images.githubusercontent.com/8156884/74094147-71bdae80-4ad4-11ea-9ad1-7514f7580f99.png)

### Why?

So that I can use vim-test with MacVim without it exploding :).

### A/C

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
