### PR TITLE
Update readme to demonstrate vertical split pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,12 +308,16 @@ let test#ruby#rspec#options = {
 
 ### Vim8 / Neovim terminal position
 
-Both the `neovim` and `Vim8 Terminal` strategy will open a split window on the bottom by default, but
-you can configure a different position:
+Both the `neovim` and `Vim8 Terminal` strategy will open a split window on the
+bottom by default, but you can configure a different position or orientation.
+Whatever you put here is passed to `new` - so, you may also specify size (see
+`:help opening-window` or `:help new` for more info):
 
 ```vim
 " for neovim
 let test#neovim#term_position = "topleft"
+let test#neovim#term_position = "vert"
+let test#neovim#term_position = "vert botright 30"
 " or for Vim8
 let test#vim#term_position = "belowright"
 ```

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -526,16 +526,20 @@ working directory for running tests:
 >
   let test#project_root = "/path/to/your/project"
 <
-If you're using either the Vim8 Terminal or Neovim strategy, you can easily configure the position of
-the terminal split window (see `:help opening-window`) with:
->
-  let test#vim#term_position = "topleft"
-<
-for vim and
+Both the `neovim` and `Vim8 Terminal` strategy will open a split window on the
+bottom by default, but you can configure a different position or orientation.
+Whatever you put here is passed to `new` - so, you may also specify size (see
+`:help opening-window` or `:help new` for more info):
 >
   let test#neovim#term_position = "topleft"
+  let test#neovim#term_position = "vert"
+  let test#neovim#term_position = "vert botright 30"
 <
-for neovim
+for neovim and
+>
+  let test#vim#term_position = "belowright"
+<
+for vim
 
 
 PROJECTIONIST INTEGRATION                       *test-projectionist*


### PR DESCRIPTION
It took me a little while to find https://github.com/janko/vim-test/pull/309 but this feature is already included so it might make sense to document it! I also updated the `doc/test.txt` file to keep it in sync with the README

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
