### PR TITLE
Fix kitty runner script

### DIFF
--- a/bin/kitty_runner
+++ b/bin/kitty_runner
@@ -1,8 +1,8 @@
 #!/usr/bin/env sh
-if [[ `kitty @ ls | grep -c '            "title": "vim-test-output'` -eq 0 ]];
+if [ "$(kitty @ ls | grep -c '            "title": "vim-test-output')" -eq 0 ];
 then
-  kitty @ --to $KITTY_LISTEN_ON new-window --keep-focus --title "vim-test-output" $SHELL
+  kitty @ --to "$KITTY_LISTEN_ON" new-window --keep-focus --title "vim-test-output" "$SHELL"
 fi
 
-kitty @ --to $KITTY_LISTEN_ON send-text --match title:"vim-test-output" "$1\x0d"
+kitty @ --to "$KITTY_LISTEN_ON" send-text --match title:"vim-test-output" "$1\x0d"
 


### PR DESCRIPTION
Fixes the kitty runner script so that it's Posix compliant and works on
Gnu/Linux systems.

I just ran the script through shellcheck [1] and followed its
directions.

- [1] https://www.shellcheck.net/

I don't believe there's any necessary doc changes.

Make sure these boxes are checked before submitting your pull request:

- [ ] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
