### PR TITLE
Add support for TestNearest for shell#bats

### DIFF
--- a/autoload/test/shell/bats.vim
+++ b/autoload/test/shell/bats.vim
@@ -2,12 +2,28 @@ if !exists('g:test#shell#bats#file_pattern')
   let g:test#shell#bats#file_pattern = '\v\.bats$'
 endif
 
+if !exists('g:test#shell#bats#patterns')
+  let g:test#shell#bats#patterns = {
+        \ 'test': [
+        \ '\v^\s*\@test %("|'')(.*)%("|'')'
+        \ ],
+        \ 'namespace': []
+        \ }
+endif
+
 function! test#shell#bats#test_file(file) abort
   return a:file =~# g:test#shell#bats#file_pattern
 endfunction
 
 function! test#shell#bats#build_position(type, position) abort
-  if a:type ==# 'nearest' || a:type ==# 'file'
+  if a:type ==# 'nearest'
+    let name = test#base#nearest_test(a:position, g:test#shell#bats#patterns)
+    if empty(name['test'])
+      return []
+    else
+      return [a:position['file'], '-f', '''^'.name['test'][0].'$''']
+    endif
+  elseif a:type ==# 'file'
     return [a:position['file']]
   else
     return []

--- a/spec/bats_spec.vim
+++ b/spec/bats_spec.vim
@@ -11,11 +11,26 @@ describe "Bats"
     cd -
   end
 
-  it "runs file tests instead of nearest tests"
-    view normal.bats
+  it "runs nearest test"
+    view +6 normal.bats
     TestNearest
 
-    Expect g:test#last_command == 'bats normal.bats'
+    Expect g:test#last_command == 'bats normal.bats -f ''^numbers 2$'''
+
+    view +1 normal.bats
+    TestNearest
+
+    Expect g:test#last_command == 'bats normal.bats -f ''^numbers$'''
+
+    view +10 normal.bats
+    TestNearest
+
+    Expect g:test#last_command == 'bats normal.bats -f ''^single quotes$'''
+
+    view +14 normal.bats
+    TestNearest
+
+    Expect g:test#last_command == 'bats normal.bats -f ''^indented$'''
   end
 
   it "runs file tests"

--- a/spec/fixtures/bats/normal.bats
+++ b/spec/fixtures/bats/normal.bats
@@ -1,3 +1,15 @@
 @test "numbers" {
   [ 1 -eq 1 ]
 }
+
+@test "numbers 2" {
+  [ 1 -eq 1 ]
+}
+
+@test 'single quotes' {
+  [ 1 -eq 1 ]
+}
+
+   @test 'indented' {
+     [ 1 -eq 1 ]
+   }


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`

---

Currently for shell#bats tests, TestNearest are always treated as TestFile. This adds support for TestNearest in shell bats files.