### PR TITLE
Add AsyncRun background variation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,27 +80,27 @@ Test.vim can run tests using different execution environments called
 let test#strategy = "dispatch"
 ```
 
-| Strategy                        | Identifier                       | Description                                                                      |
-| :-----:                         | :-----:                          | :----------                                                                      |
-| **Basic**&nbsp;(default)        | `basic`                          | Runs test commands with `:!` on Vim, and with `:terminal` on Neovim.             |
-| **Make**                        | `make` `make_bang`               | Runs test commands with `:make` or `:make!`.                                     |
-| **Neovim**                      | `neovim`                         | Runs test commands with `:terminal` in a split window.                           |
-| **Vim8 Terminal**               | `vimterminal`                    | Runs test commands with `term_start()` in a split window.                        |
-| **[Dispatch]**                  | `dispatch` `dispatch_background` | Runs test commands with `:Dispatch` or `:Dispatch!`.                             |
-| **[Vimux]**                     | `vimux`                          | Runs test commands in a small tmux pane at the bottom of your terminal.          |
-| **[Tslime]**                    | `tslime`                         | Runs test commands in a tmux pane you specify.                                   |
-| **[Slimux]**                    | `slimux`                         | Runs test commands in a tmux pane you specify.                                   |
-| **[Neoterm]**                   | `neoterm`                        | Runs test commands with `:T`, see neoterm docs for display customization.        |
-| **[Neomake]**                   | `neomake`                        | Runs test commands asynchronously with `:NeomakeProject`.                        |
-| **[MakeGreen]**                 | `makegreen`                      | Runs test commands with `:MakeGreen`.                                            |
-| **[VimShell]**                  | `vimshell`                       | Runs test commands in a shell written in VimScript.                              |
-| **[Vim&nbsp;Tmux&nbsp;Runner]** | `vtr`                            | Runs test commands in a small tmux pane.                                         |
-| **[VimProc]**                   | `vimproc`                        | Runs test commands asynchronously.                                               |
-| **[AsyncRun]**                  | `asyncrun`                       | Runs test commands asynchronosuly using new APIs in Vim 8 and NeoVim.            |
-| **Terminal.app**                | `terminal`                       | Sends test commands to Terminal (useful in MacVim GUI).                          |
-| **iTerm2.app**                  | `iterm`                          | Sends test commands to iTerm2 >= 2.9 (useful in MacVim GUI).                     |
-| **[Kitty]**                     | `kitty`                          | Sends test commands to Kitty terminal.                                           |
-| **[Shtuff]**                    | `shtuff`                         | Sends test commands to remote terminal via [shtuff][Shtuff].                     |
+| Strategy                        | Identifier                       | Description                                                                                                |
+| :-----:                         | :-----:                          | :----------                                                                                                |
+| **Basic**&nbsp;(default)        | `basic`                          | Runs test commands with `:!` on Vim, and with `:terminal` on Neovim.                                       |
+| **Make**                        | `make` `make_bang`               | Runs test commands with `:make` or `:make!`.                                                               |
+| **Neovim**                      | `neovim`                         | Runs test commands with `:terminal` in a split window.                                                     |
+| **Vim8 Terminal**               | `vimterminal`                    | Runs test commands with `term_start()` in a split window.                                                  |
+| **[Dispatch]**                  | `dispatch` `dispatch_background` | Runs test commands with `:Dispatch` or `:Dispatch!`.                                                       |
+| **[Vimux]**                     | `vimux`                          | Runs test commands in a small tmux pane at the bottom of your terminal.                                    |
+| **[Tslime]**                    | `tslime`                         | Runs test commands in a tmux pane you specify.                                                             |
+| **[Slimux]**                    | `slimux`                         | Runs test commands in a tmux pane you specify.                                                             |
+| **[Neoterm]**                   | `neoterm`                        | Runs test commands with `:T`, see neoterm docs for display customization.                                  |
+| **[Neomake]**                   | `neomake`                        | Runs test commands asynchronously with `:NeomakeProject`.                                                  |
+| **[MakeGreen]**                 | `makegreen`                      | Runs test commands with `:MakeGreen`.                                                                      |
+| **[VimShell]**                  | `vimshell`                       | Runs test commands in a shell written in VimScript.                                                        |
+| **[Vim&nbsp;Tmux&nbsp;Runner]** | `vtr`                            | Runs test commands in a small tmux pane.                                                                   |
+| **[VimProc]**                   | `vimproc`                        | Runs test commands asynchronously.                                                                         |
+| **[AsyncRun]**                  | `asyncrun` `asyncrun_background` | Runs test commands asynchronosuly using new APIs in Vim 8 and NeoVim (`:AsyncRun` or `:AsyncRun -open=0`). |
+| **Terminal.app**                | `terminal`                       | Sends test commands to Terminal (useful in MacVim GUI).                                                    |
+| **iTerm2.app**                  | `iterm`                          | Sends test commands to iTerm2 >= 2.9 (useful in MacVim GUI).                                               |
+| **[Kitty]**                     | `kitty`                          | Sends test commands to Kitty terminal.                                                                     |
+| **[Shtuff]**                    | `shtuff`                         | Sends test commands to remote terminal via [shtuff][Shtuff].                                               |
 
 You can also set up strategies per granularity:
 

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -36,6 +36,26 @@ function! test#strategy#asyncrun(cmd) abort
   execute 'AsyncRun '.a:cmd
 endfunction
 
+function! test#strategy#asyncrun_background_status() abort
+  if g:asyncrun_code == 0
+    return "Success"
+  endif
+  return "Failure"
+endfunction
+
+function! test#strategy#asyncrun_background_pretty() abort
+  return substitute(g:test#background_cmd, '\', '', '')
+endfunction
+
+function! test#strategy#asyncrun_background(cmd) abort
+  let g:test#strategy#cmd = a:cmd
+  augroup asyncrun_background
+    autocmd!
+    autocmd User AsyncRunStop if exists('g:test#strategy#cmd') | unlet g:test#strategy#cmd | endif
+  augroup END
+  execute 'AsyncRun -silent -post=echom\ test\#strategy\#asyncrun_background_status().":"\ test\#strategy\#asyncrun_background_pretty() '.a:cmd
+endfunction
+
 function! test#strategy#dispatch(cmd) abort
   execute 'Dispatch '.a:cmd
 endfunction

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -258,7 +258,7 @@ AsyncRun ~
 Runs test commands asynchronously using new APIs in Vim 8 and NeoVim.
 Requires AsyncRun plugin.
 >
-  let test#strategy = 'asyncrun'
+  let test#strategy = 'asyncrun' or 'asyncrun_background'
 <
 Basic (default) ~
 


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [ ] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`

I would be happy to add tests for this with some guidance. I didn't see any for `AsyncRun` though.

[`pretty`](https://github.com/janko/vim-test/compare/master...webdavis:asyncrun_background?expand=1#diff-52fe4cbf4297c73b5a08849fdfa5eb1cR46) removes escape characters added by `AsyncRun`.

[`status`](https://github.com/janko/vim-test/compare/master...webdavis:asyncrun_background?expand=1#diff-52fe4cbf4297c73b5a08849fdfa5eb1cR39) prepends `Success` or `Failure` to the test for easy feedback. That way the user knows to open the quickfix when a test fails.

skywind3000/asyncrun.vim#178 makes this possible. 