### PR TITLE
Fix TestNearest alternative with exunit

### DIFF
--- a/autoload/test/elixir/exunit.vim
+++ b/autoload/test/elixir/exunit.vim
@@ -9,7 +9,11 @@ endfunction
 function! test#elixir#exunit#build_position(type, position) abort
   if test#elixir#exunit#executable() ==# 'mix test'
     if a:type ==# 'nearest'
-      return [a:position['file'].':'.a:position['line']]
+      if a:position['line'] > 1
+          return [a:position['file'].':'.a:position['line']]
+      else
+          return [a:position['file']]
+      endif
     elseif a:type ==# 'file'
       return [a:position['file']]
     else

--- a/spec/exunit_spec.vim
+++ b/spec/exunit_spec.vim
@@ -16,11 +16,18 @@ describe "ExUnit"
       view +1 normal_test.exs
       TestNearest
 
-      Expect g:test#last_command == 'mix test normal_test.exs:1'
+      Expect g:test#last_command == 'mix test normal_test.exs'
+    end
+
+    it "runs specific nearest test"
+      view +6 normal_test.exs
+      TestNearest
+
+      Expect g:test#last_command == 'mix test normal_test.exs:6'
     end
 
     it "runs file tests"
-      view normal_test.exs
+      view +1 normal_test.exs
       TestFile
 
       Expect g:test#last_command == 'mix test normal_test.exs'


### PR DESCRIPTION
Running mix test with line numbers only selects tests if the line
contains a test block.  The default position for alternative file is
line 1 which generally contains the module, resulting in no tests being
selected.

    $ mix test test/example_test.exs:1
    Excluding tags: [:test]
    Including tags: [line: "1"]

    Finished in 0.04 seconds
    1 test, 0 failures, 1 excluded

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
