### PR TITLE
Fix neovim strategy focusing terminal buffer

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -76,7 +76,13 @@ function! test#strategy#neovim(cmd) abort
   execute term_position . ' new'
   call termopen(a:cmd)
   au BufDelete <buffer> wincmd p " switch back to last window on delete
-  execute feedkeys("G\<C-W>\<C-P>") " switch back to last window
+
+  " Start insert mode only when running a specific test
+  if stridx(a:cmd, '--filter') != -1
+      startinsert
+  else
+    execute feedkeys("G\<C-W>\<C-P>")
+  endif
 endfunction
 
 function! test#strategy#vimterminal(cmd) abort

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -75,8 +75,8 @@ function! test#strategy#neovim(cmd) abort
   let term_position = get(g:, 'test#neovim#term_position', 'botright')
   execute term_position . ' new'
   call termopen(a:cmd)
-  au BufDelete <buffer> wincmd p " switch back to last window
-  startinsert
+  au BufDelete <buffer> wincmd p " switch back to last window on delete
+  execute feedkeys("G\<C-W>\<C-P>") " switch back to last window
 endfunction
 
 function! test#strategy#vimterminal(cmd) abort


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`

This PR fixes #448.

The issue was `startinsert` which causes the insert mode in terminal and then you have to go back to your previous buffer manually.

To fix this, I've patched the strategy to have the same behaviour if when running a filtered test (`--filter`), otherwise, automatically go back to previous buffer.

The send the keys `G` to follow the scrolling of the terminal buffer and `<C-W><C-P>` to switch back to the last window.

The reason why I'm leaving the old behaviour for filtered test is because you expect a quick result when running a single test, so you don't want to manually change back to the terminal buffer. When running a suite or file, the tests could take longer, hence going back to your previous buffer to continue your work.