### PR TITLE
Add tmuxify strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ let test#strategy = "dispatch"
 | **[MakeGreen]**                 | `makegreen`                                                 | Runs test commands with `:MakeGreen`.                                                                                                                             |
 | **[VimShell]**                  | `vimshell`                                                  | Runs test commands in a shell written in VimScript.                                                                                                               |
 | **[Vim&nbsp;Tmux&nbsp;Runner]** | `vtr`                                                       | Runs test commands in a small tmux pane.                                                                                                                          |
+| **[Tmuxify]**                   | `tmuxify`                                                   | Runs test commands in a small tmux pane at the bottom of your terminal.                                                                                                                    |
 | **[VimProc]**                   | `vimproc`                                                   | Runs test commands asynchronously.                                                                                                                                |
 | **[AsyncRun]**                  | `asyncrun` `asyncrun_background` `asyncrun_background_term` | Runs test commands asynchronosuly using new APIs in Vim 8 and NeoVim (`:AsyncRun`, `:AsyncRun -mode=async -silent`, or `:AsyncRun -mode=term -pos=tab -focus=0`). |
 | **Terminal.app**                | `terminal`                                                  | Sends test commands to Terminal (useful in MacVim GUI).                                                                                                           |
@@ -597,6 +598,7 @@ Copyright © Janko Marohnić. Distributed under the same terms as Vim itself. Se
 [Tslime]: https://github.com/jgdavey/tslime.vim
 [Slimux]: https://github.com/esamattis/slimux
 [Vim&nbsp;Tmux&nbsp;Runner]: https://github.com/christoomey/vim-tmux-runner
+[Tmuxify]: https://github.com/jebaum/vim-tmuxify
 [VimShell]: https://github.com/Shougo/vimshell.vim
 [VimProc]: https://github.com/Shougo/vimproc.vim
 [`autochdir`]: http://vimdoc.sourceforge.net/htmldoc/options.html#'autochdir'

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -121,6 +121,16 @@ function! test#strategy#slimux(cmd) abort
   endif
 endfunction
 
+function! test#strategy#tmuxify(cmd) abort
+  call tmuxify#pane_send_raw("'C-u q C-u'", '!')
+
+  if exists('g:test#preserve_screen') && !g:test#preserve_screen
+    call tmuxify#pane_send_raw("'C-u C-l C-u'", '!')
+  endif
+
+  call tmuxify#pane_run('!', s:command(a:cmd))
+endfunction
+
 function! test#strategy#vimshell(cmd) abort
   execute 'VimShellExecute '.a:cmd
 endfunction

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -328,6 +328,13 @@ Requires the Vimux plugin and Tmux.
 >
   let test#strategy = 'vimux'
 <
+Tmuxify ~
+
+Runs test commands in a small Tmux pane at the bottom of your Terminal.
+Requires the Tmuxify plugin and Tmux.
+>
+  let test#strategy = 'tmuxify'
+<
 Tslime ~
 
 Runs test commands in a Tmux pane you specify. Requires the Tslime.vim plugin


### PR DESCRIPTION
Add strategy for [vim-tmuxify](https://github.com/jebaum/vim-tmuxify) - yet another plugin to integrate vim with tmux.

Note: I did not use internal pretty command to avoid logging long commands in history. I used `C-u C-l C-u` for screen clear.

Please help me to review it. Thanks.


Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
