### PR TITLE
Tweak tmuxify strategy a bit

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -123,7 +123,7 @@ endfunction
 
 function! test#strategy#tmuxify(cmd) abort
   call tmuxify#pane_send_raw('C-u', '!')
-  call tmuxify#pane_send_raw('C-q', '!')
+  call tmuxify#pane_send_raw('q', '!')
   call tmuxify#pane_send_raw('C-u', '!')
 
   if exists('g:test#preserve_screen') && !g:test#preserve_screen

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -122,10 +122,14 @@ function! test#strategy#slimux(cmd) abort
 endfunction
 
 function! test#strategy#tmuxify(cmd) abort
-  call tmuxify#pane_send_raw("'C-u q C-u'", '!')
+  call tmuxify#pane_send_raw('C-u', '!')
+  call tmuxify#pane_send_raw('C-q', '!')
+  call tmuxify#pane_send_raw('C-u', '!')
 
   if exists('g:test#preserve_screen') && !g:test#preserve_screen
-    call tmuxify#pane_send_raw("'C-u C-l C-u'", '!')
+    call tmuxify#pane_send_raw('C-u', '!')
+    call tmuxify#pane_send_raw('C-l', '!')
+    call tmuxify#pane_send_raw('C-u', '!')
   endif
 
   call tmuxify#pane_run('!', s:command(a:cmd))


### PR DESCRIPTION
 `tmuxify#pane_send_raw` send keys as single to pane, in some program
 like `less` it can understand these keys. However, tmux in copy mode
 does not understand it.

Please help me to review this PR. Thanks.
