### PR TITLE
fix cargotests run from /tests

### DIFF
--- a/autoload/test/rust/cargotest.vim
+++ b/autoload/test/rust/cargotest.vim
@@ -5,7 +5,7 @@ endif
 if !exists('g:test#rust#cargotest#test_patterns')
   let g:test#rust#cargotest#test_patterns = {
         \ 'test': ['\v(#\[test\])'],
-        \ 'namespace': []
+        \ 'namespace': ['\vmod (tests?)']
     \ }
 endif
 
@@ -61,14 +61,18 @@ function! s:nearest_test(position) abort
 
   " Else
   " Search forward for the first declared method
-  let name = test#base#nearest_test_in_lines(
+  let name_f = test#base#nearest_test_in_lines(
     \ a:position['file'],
     \ name['test_line'],
     \ a:position['line'],
     \ g:test#rust#cargotest#patterns
   \ )
 
-  return join(name['test'])
+  if len(name['namespace']) > 0
+    return join([name['namespace'][0], name_f['test'][0]], '::')
+  else
+    return name_f['test'][0]
+  endif
 endfunction
 
 function! s:test_namespace(filename) abort
@@ -87,7 +91,11 @@ function! s:test_namespace(filename) abort
   if l:modules[0] == 'tests' && len(l:modules) == 2
     return ''
   else
-    let l:modules = l:modules[1:] + ['tests']
-    return join(l:modules, '::') . '::'
+    let l:modules = l:modules[1:]
+    if len(l:modules) > 0
+      return join(l:modules, '::') . '::'
+    else
+      return ''
+    endif
   endif
 endfunction

--- a/autoload/test/rust/cargotest.vim
+++ b/autoload/test/rust/cargotest.vim
@@ -11,7 +11,7 @@ endif
 
 if !exists('g:test#rust#cargotest#patterns')
   let g:test#rust#cargotest#patterns = {
-        \ 'test': ['\v\s+fn\s+(\w+)'],
+        \ 'test': ['\v\s*fn\s+(\w+)'],
         \ 'namespace': []
     \ }
 endif
@@ -74,7 +74,7 @@ endfunction
 function! s:test_namespace(filename) abort
   let l:path = fnamemodify(a:filename, ':r')
   " On a normal cargo project, the first item is 'src'
-  let l:modules = split(l:path, '/')[1:]
+  let l:modules = split(l:path, '/')
 
   " 'src/lib.rs' and 'src/some/mod.rs' does not end
   " with actual module names
@@ -82,7 +82,12 @@ function! s:test_namespace(filename) abort
     let l:modules = l:modules[:-2]
   endif
 
+
   " Build up tests module namespace
-  let l:modules = l:modules + ['tests']
-  return join(l:modules, '::') . '::'
+  if l:modules[0] == 'tests' && len(l:modules) == 2
+    return ''
+  else
+    let l:modules = l:modules[1:] + ['tests']
+    return join(l:modules, '::') . '::'
+  endif
 endfunction

--- a/spec/cargotest_spec.vim
+++ b/spec/cargotest_spec.vim
@@ -14,19 +14,19 @@ describe "Cargo"
   it "runs file tests"
     view src/lib.rs
     TestFile
-    Expect g:test#last_command == 'cargo test ''tests::'''
+    Expect g:test#last_command == 'cargo test '''''
 
     view src/somemod.rs
     TestFile
-    Expect g:test#last_command == 'cargo test ''somemod::tests::'''
+    Expect g:test#last_command == 'cargo test ''somemod::'''
 
     view src/nested/mod.rs
     TestFile
-    Expect g:test#last_command == 'cargo test ''nested::tests::'''
+    Expect g:test#last_command == 'cargo test ''nested::'''
 
     view src/too/nested.rs
     TestFile
-    Expect g:test#last_command == 'cargo test ''too::nested::tests::'''
+    Expect g:test#last_command == 'cargo test ''too::nested::'''
   end
 
   it "runs nearest test on lib.rs"
@@ -41,6 +41,35 @@ describe "Cargo"
     view +7 src/lib.rs
     TestNearest
     Expect g:test#last_command == 'cargo test ''tests::second_test'' -- --exact'
+  end
+
+
+  it "runs nearest test on modules with mod as test"
+    view +5 src/somemod_test.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod_test::test::first_test'' -- --exact'
+
+    view +13 src/somemod_test.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod_test::test::third_test'' -- --exact'
+
+    view +7 src/somemod_test.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod_test::test::second_test'' -- --exact'
+  end
+
+  it "runs nearest test without mod"
+    view +2 src/nomod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nomod::first_test'' -- --exact'
+
+    view +10 src/nomod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nomod::third_test'' -- --exact'
+
+    view +6 src/nomod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nomod::second_test'' -- --exact'
   end
 
   it "runs nearest test on modules"

--- a/spec/fixtures/cargo/src/nomod.rs
+++ b/spec/fixtures/cargo/src/nomod.rs
@@ -1,0 +1,11 @@
+#[test]
+fn first_test () {
+}
+
+#[test]
+fn second_test () {
+}
+
+#[test]
+fn third_test () {
+}

--- a/spec/fixtures/cargo/src/somemod_test.rs
+++ b/spec/fixtures/cargo/src/somemod_test.rs
@@ -1,0 +1,13 @@
+mod test {
+    #[test]
+    fn first_test () {
+    }
+
+    #[test]
+    fn second_test () {
+    }
+
+    #[test]
+    fn third_test () {
+    }
+}


### PR DESCRIPTION
Added support when there is no `mod` defined or if the mod name is `test` instead of `tests`

---

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
